### PR TITLE
[claude] Fix Slab range check bug (issue #41)

### DIFF
--- a/src/TriangleMeshOctree.cpp
+++ b/src/TriangleMeshOctree.cpp
@@ -234,7 +234,7 @@ bool TriangleMeshOctree::intersectsNode(const Ray & ray, float minDistance, floa
 {
     const auto & node = nodes[nodeIndex];
 
-    if(!node.bounds.intersects(ray, minDistance, maxDistance))
+    if(!node.bounds.intersectsVolume(ray, minDistance, maxDistance))
        return false;
 
     if(node.numTriangles > 0) {
@@ -281,7 +281,7 @@ bool TriangleMeshOctree::findIntersectionNode(const Ray & ray, float minDistance
     const auto & node = nodes[nodeIndex];
     bool hit = false;
 
-    if(!node.bounds.intersects(ray, minDistance, std::numeric_limits<float>::max()))
+    if(!node.bounds.intersectsVolume(ray, minDistance, std::numeric_limits<float>::max()))
        return false;
     
     hit |= findIntersectionNodeTriangles(

--- a/src/slab.h
+++ b/src/slab.h
@@ -45,6 +45,10 @@ struct Slab : public Traceable
     inline virtual bool intersects(const Ray & ray, float minDistance, float maxDistance) const override;
     inline virtual bool findIntersection(const Ray & ray, float minDistance, RayIntersection & intersection) const override;
 
+    // Volume intersection: true if the ray segment [minDistance, maxDistance] overlaps the slab volume.
+    // Use this for bounding box / accelerator tests where the origin may be inside the slab.
+    inline bool intersectsVolume(const Ray & ray, float minDistance, float maxDistance) const;
+
     // Bounding volume
     Slab boundingBox() override { return *this; }
 

--- a/src/slab.hpp
+++ b/src/slab.hpp
@@ -26,34 +26,49 @@ inline bool Slab::contains(const Position3 & P) const
         zmin <= P.z && zmax >= P.z;
 }
 
-inline bool Slab::intersects(const Ray & ray, float minDistance, float maxDistance) const
+inline void slabRayT(const Slab & slab, const Ray & ray, float & tmin, float & tmax)
 {
     float dinvx = 1.0f / ray.direction.x;
     float dinvy = 1.0f / ray.direction.y;
     float dinvz = 1.0f / ray.direction.z;
-    vec3 dinv(dinvx, dinvy, dinvz);
 
-    float tx1 = (xmin - ray.origin.x) * dinv.x;
-    float tx2 = (xmax - ray.origin.x) * dinv.x;
+    float tx1 = (slab.xmin - ray.origin.x) * dinvx;
+    float tx2 = (slab.xmax - ray.origin.x) * dinvx;
+    tmin = std::min(tx1, tx2);
+    tmax = std::max(tx1, tx2);
 
-    float tmin = std::min(tx1, tx2);
-    float tmax = std::max(tx1, tx2);
-
-    float ty1 = (ymin - ray.origin.y) * dinv.y;
-    float ty2 = (ymax - ray.origin.y) * dinv.y;
-
+    float ty1 = (slab.ymin - ray.origin.y) * dinvy;
+    float ty2 = (slab.ymax - ray.origin.y) * dinvy;
     tmin = std::max(tmin, std::min(ty1, ty2));
     tmax = std::min(tmax, std::max(ty1, ty2));
 
-    float tz1 = (zmin - ray.origin.z) * dinv.z;
-    float tz2 = (zmax - ray.origin.z) * dinv.z;
-
+    float tz1 = (slab.zmin - ray.origin.z) * dinvz;
+    float tz2 = (slab.zmax - ray.origin.z) * dinvz;
     tmin = std::max(tmin, std::min(tz1, tz2));
     tmax = std::min(tmax, std::max(tz1, tz2));
+}
 
-    return tmax >= tmin
-        && (tmin >= minDistance || tmax >= minDistance)
-        && (tmin <= maxDistance || tmax <= maxDistance);
+// Surface intersection: returns true if the ray hits a slab face within [minDistance, maxDistance].
+// When the ray origin is inside the slab, only the exit face counts.
+inline bool Slab::intersects(const Ray & ray, float minDistance, float maxDistance) const
+{
+    float tmin, tmax;
+    slabRayT(*this, ray, tmin, tmax);
+
+    if(tmax < tmin) return false;       // ray misses slab entirely
+    if(tmax < minDistance) return false; // slab entirely behind ray
+    float t = (tmin >= minDistance) ? tmin : tmax; // nearest surface within range
+    return t <= maxDistance;
+}
+
+// Volume intersection: returns true if the ray segment [minDistance, maxDistance] overlaps
+// the slab volume. Use for bounding box / accelerator tests where origin may be inside.
+inline bool Slab::intersectsVolume(const Ray & ray, float minDistance, float maxDistance) const
+{
+    float tmin, tmax;
+    slabRayT(*this, ray, tmin, tmax);
+
+    return tmax >= tmin && tmax >= minDistance && tmin <= maxDistance;
 }
 
 static const Direction3 boxNormals[6] = {

--- a/unittests/rayslab.cpp
+++ b/unittests/rayslab.cpp
@@ -63,6 +63,42 @@ TEST(RaySlabIntersectTest, OffCenterDiagonalRay_OffCenterSlab_IntersectsTrue) {
                                 minDistance, maxDistance));
 }
 
+// Origin inside slab: exit surface within maxDistance -> surface hit
+TEST(RaySlabIntersectTest, OriginInsideSlab_ExitWithinMaxDist_IntersectsTrue) {
+    Slab obj(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
+    const float minDistance = 0.01f;
+    // exit along +x is at t=1.0, maxDistance=2.0 -> should hit
+    EXPECT_TRUE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(1, 0, 0)), minDistance, 2.0f));
+    EXPECT_TRUE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(-1, 0, 0)), minDistance, 2.0f));
+    EXPECT_TRUE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(0, 1, 0)), minDistance, 2.0f));
+    EXPECT_TRUE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(0, 0, 1)), minDistance, 2.0f));
+}
+
+// Origin inside slab: exit surface beyond maxDistance -> no surface hit in range
+TEST(RaySlabIntersectTest, OriginInsideSlab_ExitBeyondMaxDist_IntersectsFalse) {
+    Slab obj(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
+    const float minDistance = 0.01f;
+    // exit along +x is at t=1.0, maxDistance=0.5 -> no surface within range
+    EXPECT_FALSE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(1, 0, 0)), minDistance, 0.5f));
+    EXPECT_FALSE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(-1, 0, 0)), minDistance, 0.5f));
+    EXPECT_FALSE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(0, 1, 0)), minDistance, 0.5f));
+    EXPECT_FALSE(obj.intersects(Ray(Position3(0, 0, 0), Direction3(0, 0, 1)), minDistance, 0.5f));
+}
+
+// intersectsVolume: origin inside slab, exit beyond maxDistance -> volume still overlaps range
+TEST(RaySlabIntersectVolumeTest, OriginInsideSlab_ExitBeyondMaxDist_VolumeIntersectsTrue) {
+    Slab obj(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
+    const float minDistance = 0.01f;
+    EXPECT_TRUE(obj.intersectsVolume(Ray(Position3(0, 0, 0), Direction3(1, 0, 0)), minDistance, 0.5f));
+}
+
+// intersectsVolume: slab entirely behind ray -> false
+TEST(RaySlabIntersectVolumeTest, SlabBehindRay_VolumeIntersectsFalse) {
+    Slab obj(-1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
+    const float minDistance = 0.01f, maxDistance = 1000.0f;
+    EXPECT_FALSE(obj.intersectsVolume(Ray(Position3(10, 0, 0), Direction3(1, 0, 0)), minDistance, maxDistance));
+}
+
 // ---------------------- Find Intersection Tests ------------------------
 
 TEST(RaySlabFindIntersectionTest, OnAxisCenteredRay_CenteredSlab_FindsFirstIntersection) {


### PR DESCRIPTION
Fixes #41.

## Problem

`Slab::intersects` was using **volume semantics** — it returned true whenever the ray segment `[minDistance, maxDistance]` overlapped the slab's volume. This caused shadow rays to be incorrectly blocked when the ray origin is inside the slab and the exit surface is beyond the light's distance.

All other `Traceable` types use **surface semantics** (does the ray hit a surface within range?), so `Slab` was inconsistent.

## Fix

- `Slab::intersects`: now computes the actual surface intersection `t`, then checks it against `[minDistance, maxDistance]`. Consistent with `Sphere`, `Triangle`, etc.
- `Slab::intersectsVolume`: new method using interval-overlap logic, intended for bounding box / accelerator tests where volume semantics is correct.
- `TriangleMeshOctree::intersectsNode` / `findIntersectionNode`: updated to call `intersectsVolume` so the octree's bounding box culling is unaffected.

## Tests

Added to `unittests/rayslab.cpp`:
- `OriginInsideSlab_ExitWithinMaxDist_IntersectsTrue` — normal inside-slab hit
- `OriginInsideSlab_ExitBeyondMaxDist_IntersectsFalse` — the bug case
- `OriginInsideSlab_ExitBeyondMaxDist_VolumeIntersectsTrue` — verifies `intersectsVolume` still returns true for octree use
- `SlabBehindRay_VolumeIntersectsFalse` — sanity check on `intersectsVolume`

— Claude