### PR TITLE
[claude] Fix linker visibility warnings in python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SRCS
     src/ValueArray.cpp
     )
 ADD_LIBRARY(fluxrt ${SRCS})
+set_target_properties(fluxrt PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN YES)
 
 if(BUILD_PYTHON_BINDINGS)
     add_subdirectory(external/pybind11)

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -75,7 +75,7 @@ void Logger::logToStdout(Logger::Severity s, const std::string & msg)
                   << "\t" << msg;
     }
     if(!joinNext) {
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 }
 
@@ -178,7 +178,7 @@ void FileLogger::log(Severity s, const std::string & msg)
         messageOnlyForJoin = true;
     }
     else {
-        outFile << std::endl;
+        outFile << '\n';
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `CXX_VISIBILITY_PRESET hidden` and `VISIBILITY_INLINES_HIDDEN YES` to the `fluxrt` library target so inline symbols (e.g. `vec3::normalized()`, `Ray::pointAt()`) are hidden and consistent with pybind11's LTO-compiled module
- Replace `std::endl` with `'\n'` in `Logger.cpp` to avoid a secondary visibility conflict between `libfluxrt.a` and the precompiled `libgtest.a`

## Test plan

- [x] `pyfluxrt` links with zero linker warnings
- [x] Full build (`make`) produces zero warnings
- [x] All 19 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)