### PR TITLE
[claude] Enable OBJ emission loading with per-mesh disable option

### DIFF
--- a/src/TriangleMesh-obj.cpp
+++ b/src/TriangleMesh-obj.cpp
@@ -16,7 +16,8 @@ static void loadMaterialsFromOBJ(MaterialArray & materials,
                                  std::vector<MaterialID> & objMatToMatArrIndex,
                                  TextureCache & textureCache,
                                  std::vector<tinyobj::material_t> & objmaterials,
-                                 const std::string & path)
+                                 const std::string & path,
+                                 const TriangleMeshLoadOptions & options)
 {
     auto & logger = getLogger();
 
@@ -78,9 +79,9 @@ static void loadMaterialsFromOBJ(MaterialArray & materials,
                 material = Material::makeDiffuseSpecular(D, S);
         }
 
-        // FIXME: This is fine, but we should add a way to disable emission
-        // in loaded models so we can test without the lights they include.
-        //material.emissionColor = RadianceRGB(E);
+        if(!options.disableEmission) {
+            material.emissionColor = RadianceRGB(E[0], E[1], E[2]);
+        }
 
         material.specularExponentParam = objmaterial.shininess;
 
@@ -125,7 +126,8 @@ bool loadTriangleMeshFromOBJ(TriangleMesh & mesh,
                              MaterialArray & materials,
                              TriangleMeshDataCache & meshDataCache,
                              TextureCache & textureCache,
-                             const std::string & path, const std::string & filename)
+                             const std::string & path, const std::string & filename,
+                             const TriangleMeshLoadOptions & options)
 {
     auto & logger = getLogger();
 
@@ -161,7 +163,7 @@ bool loadTriangleMeshFromOBJ(TriangleMesh & mesh,
     // the materials array
     std::vector<MaterialID> objMatToMatArrIndex;
 
-    loadMaterialsFromOBJ(materials, objMatToMatArrIndex, textureCache, objmaterials, path);
+    loadMaterialsFromOBJ(materials, objMatToMatArrIndex, textureCache, objmaterials, path, options);
 
     mesh.meshData = std::make_shared<TriangleMeshData>();
     auto & meshData = *mesh.meshData;

--- a/src/TriangleMesh-stl.cpp
+++ b/src/TriangleMesh-stl.cpp
@@ -8,7 +8,8 @@ bool loadTriangleMeshFromSTL(TriangleMesh & mesh,
                              MaterialArray & materials,
                              TriangleMeshDataCache & meshDataCache,
                              TextureCache & textureCache,
-                             const std::string & path, const std::string & filename)
+                             const std::string & path, const std::string & filename,
+                             const TriangleMeshLoadOptions & options)
 {
     stlloader::Mesh stlmesh;
     stlloader::parse_file((path + '/' + filename).c_str(), stlmesh);

--- a/src/TriangleMesh.cpp
+++ b/src/TriangleMesh.cpp
@@ -16,7 +16,8 @@ bool loadTriangleMesh(TriangleMesh & mesh,
                       MaterialArray & materials,
                       TriangleMeshDataCache & meshDataCache,
                       TextureCache & textureCache,
-                      const std::string & pathToFile)
+                      const std::string & pathToFile,
+                      const TriangleMeshLoadOptions & options)
 {
     auto & logger = getLogger();
     logger.normal() << "Loading mesh from " << pathToFile;
@@ -39,10 +40,10 @@ bool loadTriangleMesh(TriangleMesh & mesh,
     bool success = false;
 
     if(filesystem::hasExtension(filename, ".obj")) {
-        success = loadTriangleMeshFromOBJ(mesh, materials, meshDataCache, textureCache, path, filename);
+        success = loadTriangleMeshFromOBJ(mesh, materials, meshDataCache, textureCache, path, filename, options);
     }
     else if(filesystem::hasExtension(filename, ".stl")) {
-        success = loadTriangleMeshFromSTL(mesh, materials, meshDataCache, textureCache, path, filename);
+        success = loadTriangleMeshFromSTL(mesh, materials, meshDataCache, textureCache, path, filename, options);
     }
     else {
         std::cerr << "Unrecognized mesh type " << filename << '\n';

--- a/src/TriangleMesh.h
+++ b/src/TriangleMesh.h
@@ -73,20 +73,27 @@ struct TriangleMesh : public Traceable
     MaterialID material = NoMaterial;
 };
 
+struct TriangleMeshLoadOptions {
+    bool disableEmission = false;
+};
+
 bool loadTriangleMesh(TriangleMesh & mesh,
                       MaterialArray & materials,
                       TriangleMeshDataCache & meshDataCache,
                       TextureCache & textureCache,
-                      const std::string & pathToFile);
+                      const std::string & pathToFile,
+                      const TriangleMeshLoadOptions & options = {});
 bool loadTriangleMeshFromOBJ(TriangleMesh & mesh,
                              MaterialArray & materials,
                              TriangleMeshDataCache & meshDataCache,
                              TextureCache & textureCache,
-                             const std::string & path, const std::string & filename);
+                             const std::string & path, const std::string & filename,
+                             const TriangleMeshLoadOptions & options = {});
 bool loadTriangleMeshFromSTL(TriangleMesh & mesh,
                              MaterialArray & materials,
                              TriangleMeshDataCache & meshDataCache,
                              TextureCache & textureCache,
-                             const std::string & path, const std::string & filename);
+                             const std::string & path, const std::string & filename,
+                             const TriangleMeshLoadOptions & options = {});
 
 #endif

--- a/src/scene-toml.cpp
+++ b/src/scene-toml.cpp
@@ -369,7 +369,10 @@ bool loadSceneFromParsedTOML(Scene & scene, std::shared_ptr<cpptoml::table> & to
 
                 auto mesh = std::make_shared<TriangleMesh>();
 
-                if(!loadTriangleMesh(*mesh, scene.materials, scene.meshDataCache, scene.textureCache, fullFilePath)) {
+                TriangleMeshLoadOptions meshLoadOptions;
+                meshLoadOptions.disableEmission = meshTable->get_as<bool>("disable_emission").value_or(false);
+
+                if(!loadTriangleMesh(*mesh, scene.materials, scene.meshDataCache, scene.textureCache, fullFilePath, meshLoadOptions)) {
                     throw std::runtime_error("Error loading mesh");
                 }
 


### PR DESCRIPTION
## Summary
- Fixes #37
- Adds `TriangleMeshLoadOptions` struct (currently with `disableEmission` field) threaded through all mesh load functions
- Emission is now loaded from OBJ `.mtl` materials by default (the previously commented-out line is enabled)
- A mesh entry in a scene TOML can opt out with `disable_emission = true`

## Usage
```toml
[[meshes]]
name = "my_model"
file = "model.obj"
disable_emission = true   # suppress embedded emissive materials
```

## Test plan
- [x] All 19 unit tests pass
- [x] Builds cleanly with no warnings on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)