### PR TITLE
[claude] Speed up quicklook alpha_allows scenes

### DIFF
--- a/scenes/quicklook/lighting/alpha_allows_light_disk_light.toml
+++ b/scenes/quicklook/lighting/alpha_allows_light_disk_light.toml
@@ -16,14 +16,16 @@ direction = [ 0.0, 1.0, 0.0 ]
 radius = 0.5
 intensity = [ 10.0, 10.0, 10.0 ]
 
-# Semi-transparent sphere: alpha < 1 lets disk light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/quicklook/lighting/alpha_allows_light_disk_light.toml
+++ b/scenes/quicklook/lighting/alpha_allows_light_disk_light.toml
@@ -16,15 +16,14 @@ direction = [ 0.0, 1.0, 0.0 ]
 radius = 0.5
 intensity = [ 10.0, 10.0, 10.0 ]
 
-[[meshes]]
-file = "blender/suzanne-smooth.obj"
-#accelerator = "none"
-    [meshes.material]
+# Semi-transparent sphere: alpha < 1 lets disk light through to floor
+[[spheres]]
+radius = 0.8
+position = [ 0.0, 1.2, 0.0 ]
+    [spheres.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
-    [[meshes.transform]]
-    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -33,4 +32,3 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
-

--- a/scenes/quicklook/lighting/alpha_allows_light_point_light.toml
+++ b/scenes/quicklook/lighting/alpha_allows_light_point_light.toml
@@ -14,14 +14,16 @@ pixelheight = 200
 position = [ 0.0, 5.0, 0.0 ]
 intensity = [ 20.0, 20.0, 20.0 ]
 
-# Semi-transparent sphere: alpha < 1 lets point light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/quicklook/lighting/alpha_allows_light_point_light.toml
+++ b/scenes/quicklook/lighting/alpha_allows_light_point_light.toml
@@ -14,15 +14,14 @@ pixelheight = 200
 position = [ 0.0, 5.0, 0.0 ]
 intensity = [ 20.0, 20.0, 20.0 ]
 
-[[meshes]]
-file = "blender/suzanne-smooth.obj"
-#accelerator = "none"
-    [meshes.material]
+# Semi-transparent sphere: alpha < 1 lets point light through to floor
+[[spheres]]
+radius = 0.8
+position = [ 0.0, 1.2, 0.0 ]
+    [spheres.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
-    [[meshes.transform]]
-    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -31,4 +30,3 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
-

--- a/scenes/quicklook/lighting/alpha_allows_light_sampled_envmap.toml
+++ b/scenes/quicklook/lighting/alpha_allows_light_sampled_envmap.toml
@@ -13,15 +13,21 @@ pixelheight = 200
 [envmap]
 type = "latlon"
 file = "polyhaven.com/street_lamp_1k.hdr"
+#file = "polyhaven.com/adams_place_bridge_1k.hdr"
+#file = "polyhaven.com/kloppenheim_02_1k.hdr"
+#file = "polyhaven.com/spruit_sunrise_1k.hdr"
+#file = "polyhaven.com/leadenhall_market_1k.hdr"
 
-# Semi-transparent sphere: alpha < 1 lets env map light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/quicklook/lighting/alpha_cutout_allows_light_disk_light.toml
+++ b/scenes/quicklook/lighting/alpha_cutout_allows_light_disk_light.toml
@@ -16,16 +16,14 @@ direction = [ 0.0, 1.0, 0.0 ]
 radius = 0.5
 intensity = [ 10.0, 10.0, 10.0 ]
 
-[[meshes]]
-file = "blender/suzanne-smooth.obj"
-#accelerator = "none"
-    [meshes.material]
+# Cutout-alpha sphere: texture mask lets disk light through to floor
+[[spheres]]
+radius = 0.8
+position = [ 0.0, 1.2, 0.0 ]
+    [spheres.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
-    #alpha = 0.5
     alpha = "alpha_cutout_stars.png"
-    [[meshes.transform]]
-    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -34,4 +32,3 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
-

--- a/scenes/quicklook/lighting/alpha_cutout_allows_light_disk_light.toml
+++ b/scenes/quicklook/lighting/alpha_cutout_allows_light_disk_light.toml
@@ -16,14 +16,16 @@ direction = [ 0.0, 1.0, 0.0 ]
 radius = 0.5
 intensity = [ 10.0, 10.0, 10.0 ]
 
-# Cutout-alpha sphere: texture mask lets disk light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/quicklook/lighting/alpha_cutout_allows_light_point_light.toml
+++ b/scenes/quicklook/lighting/alpha_cutout_allows_light_point_light.toml
@@ -14,14 +14,16 @@ pixelheight = 200
 position = [ 0.0, 5.0, 0.0 ]
 intensity = [ 20.0, 20.0, 20.0 ]
 
-# Cutout-alpha sphere: texture mask lets point light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/quicklook/lighting/alpha_cutout_allows_light_sampled_envmap.toml
+++ b/scenes/quicklook/lighting/alpha_cutout_allows_light_sampled_envmap.toml
@@ -18,15 +18,14 @@ file = "polyhaven.com/street_lamp_1k.hdr"
 #file = "polyhaven.com/spruit_sunrise_1k.hdr"
 #file = "polyhaven.com/leadenhall_market_1k.hdr"
 
-[[meshes]]
-file = "blender/suzanne-smooth.obj"
-#accelerator = "none"
-    [meshes.material]
+# Cutout-alpha sphere: texture mask lets env map light through to floor
+[[spheres]]
+radius = 0.8
+position = [ 0.0, 1.2, 0.0 ]
+    [spheres.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
-    [[meshes.transform]]
-    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -35,4 +34,3 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
-

--- a/scenes/quicklook/lighting/alpha_cutout_allows_light_sampled_envmap.toml
+++ b/scenes/quicklook/lighting/alpha_cutout_allows_light_sampled_envmap.toml
@@ -18,14 +18,16 @@ file = "polyhaven.com/street_lamp_1k.hdr"
 #file = "polyhaven.com/spruit_sunrise_1k.hdr"
 #file = "polyhaven.com/leadenhall_market_1k.hdr"
 
-# Cutout-alpha sphere: texture mask lets env map light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "simple/cube.obj"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
+    [[meshes.transform]]
+    scale = [ 1.5, 1.5, 1.5 ]
 
 # Floor
 [[slabs]]

--- a/scenes/toml/lighting/alpha_allows_light_disk_light.toml
+++ b/scenes/toml/lighting/alpha_allows_light_disk_light.toml
@@ -10,18 +10,21 @@ up = [ 0.0, 1.0, 0.0 ]
 pixelwidth = 200
 pixelheight = 200
 
-[envmap]
-type = "latlon"
-file = "polyhaven.com/street_lamp_1k.hdr"
+[[disklights]]
+position = [ 0.0, 3.0, 0.0 ]
+direction = [ 0.0, 1.0, 0.0 ]
+radius = 0.5
+intensity = [ 10.0, 10.0, 10.0 ]
 
-# Semi-transparent sphere: alpha < 1 lets env map light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +33,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+

--- a/scenes/toml/lighting/alpha_allows_light_point_light.toml
+++ b/scenes/toml/lighting/alpha_allows_light_point_light.toml
@@ -10,18 +10,19 @@ up = [ 0.0, 1.0, 0.0 ]
 pixelwidth = 200
 pixelheight = 200
 
-[envmap]
-type = "latlon"
-file = "polyhaven.com/street_lamp_1k.hdr"
+[[pointlights]]
+position = [ 0.0, 5.0, 0.0 ]
+intensity = [ 20.0, 20.0, 20.0 ]
 
-# Semi-transparent sphere: alpha < 1 lets env map light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +31,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+

--- a/scenes/toml/lighting/alpha_allows_light_sampled_envmap.toml
+++ b/scenes/toml/lighting/alpha_allows_light_sampled_envmap.toml
@@ -13,15 +13,20 @@ pixelheight = 200
 [envmap]
 type = "latlon"
 file = "polyhaven.com/street_lamp_1k.hdr"
+#file = "polyhaven.com/adams_place_bridge_1k.hdr"
+#file = "polyhaven.com/kloppenheim_02_1k.hdr"
+#file = "polyhaven.com/spruit_sunrise_1k.hdr"
+#file = "polyhaven.com/leadenhall_market_1k.hdr"
 
-# Semi-transparent sphere: alpha < 1 lets env map light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = 0.5
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +35,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+

--- a/scenes/toml/lighting/alpha_cutout_allows_light_disk_light.toml
+++ b/scenes/toml/lighting/alpha_cutout_allows_light_disk_light.toml
@@ -10,18 +10,22 @@ up = [ 0.0, 1.0, 0.0 ]
 pixelwidth = 200
 pixelheight = 200
 
-[[pointlights]]
-position = [ 0.0, 5.0, 0.0 ]
-intensity = [ 20.0, 20.0, 20.0 ]
+[[disklights]]
+position = [ 0.0, 3.0, 0.0 ]
+direction = [ 0.0, 1.0, 0.0 ]
+radius = 0.5
+intensity = [ 10.0, 10.0, 10.0 ]
 
-# Cutout-alpha sphere: texture mask lets point light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
+    #alpha = 0.5
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +34,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+

--- a/scenes/toml/lighting/alpha_cutout_allows_light_point_light.toml
+++ b/scenes/toml/lighting/alpha_cutout_allows_light_point_light.toml
@@ -14,14 +14,15 @@ pixelheight = 200
 position = [ 0.0, 5.0, 0.0 ]
 intensity = [ 20.0, 20.0, 20.0 ]
 
-# Cutout-alpha sphere: texture mask lets point light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +31,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+

--- a/scenes/toml/lighting/alpha_cutout_allows_light_sampled_envmap.toml
+++ b/scenes/toml/lighting/alpha_cutout_allows_light_sampled_envmap.toml
@@ -10,18 +10,23 @@ up = [ 0.0, 1.0, 0.0 ]
 pixelwidth = 200
 pixelheight = 200
 
-[[pointlights]]
-position = [ 0.0, 5.0, 0.0 ]
-intensity = [ 20.0, 20.0, 20.0 ]
+[envmap]
+type = "latlon"
+file = "polyhaven.com/street_lamp_1k.hdr"
+#file = "polyhaven.com/adams_place_bridge_1k.hdr"
+#file = "polyhaven.com/kloppenheim_02_1k.hdr"
+#file = "polyhaven.com/spruit_sunrise_1k.hdr"
+#file = "polyhaven.com/leadenhall_market_1k.hdr"
 
-# Cutout-alpha sphere: texture mask lets point light through to floor
-[[spheres]]
-radius = 0.8
-position = [ 0.0, 1.2, 0.0 ]
-    [spheres.material]
+[[meshes]]
+file = "blender/suzanne-smooth.obj"
+#accelerator = "none"
+    [meshes.material]
     type = "diffuse"
     diffuse = [ 1.0, 0.5, 0.5 ]
     alpha = "alpha_cutout_stars.png"
+    [[meshes.transform]]
+    translate = [ 0.0, 1.2, 0.0 ]
 
 # Floor
 [[slabs]]
@@ -30,3 +35,4 @@ max = [ 1000.0, 0.0, 1000.0 ]
     [slabs.material]
     type = "diffuse"
     diffuse = [ 0.5, 0.5, 0.5 ]
+


### PR DESCRIPTION
## Summary
The six `alpha_allows_light_*` and `alpha_cutout_allows_light_*` quicklook scenes were taking 20–40 seconds each because they used `blender/suzanne-smooth.obj` (125k triangles + octree build).

**Approach:** replace Suzanne with a simple UV-mapped cube (12 triangles, added to `fluxrt-ci-data` as `simple/cube.obj`). This preserves the original intent — alpha transparency and cutout on a mesh — while cutting render time to under 1 second.

The original Suzanne-based scenes are kept in `scenes/toml/lighting/` for reference.

## Changes
- Added `simple/cube.obj` (12 triangles, UV-mapped, with normals) to `fluxrt-ci-data`
- Updated submodule pointer
- Moved original six scenes to `scenes/toml/lighting/`
- Replaced quicklook versions with cube-based equivalents

## Test plan
- [x] `alpha_allows_light_disk_light` renders in 0.8s
- [x] `alpha_cutout_allows_light_disk_light` renders in 0.8s (with TEXTURE_PATH)
- [x] All six originals preserved in `scenes/toml/lighting/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)