### PR TITLE
[claude] Speed up env map sampling with Walker alias table and direct pixel fetch

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -33,5 +33,8 @@ target_link_libraries(random_bench ${LIBS})
 add_executable(stdlib_bench stdlib.cpp)
 target_link_libraries(stdlib_bench ${LIBS})
 
+add_executable(envmap_sampling_bench envmap_sampling.cpp)
+target_link_libraries(envmap_sampling_bench ${LIBS})
+
 
 

--- a/benchmarks/envmap_sampling.cpp
+++ b/benchmarks/envmap_sampling.cpp
@@ -1,0 +1,238 @@
+#include <benchmark/benchmark.h>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+
+#include "image.h"
+#include "LatLonEnvironmentMap.h"
+#include "rng.h"
+#include "interpolation.h"
+#include "constants.h"
+#include "vectortypes.h"
+#include "Ray.h"
+
+// ---------------------------------------------------------------------------
+// Synthetic environment map: uniform base + two bright circular features
+// ---------------------------------------------------------------------------
+
+static Image<float> makeSyntheticEnvMap(int w, int h)
+{
+    Image<float> img(w, h, 3);
+    img.setAll(0.1f);
+
+    auto circle = [&](float cx, float cy, float r, float r_val, float g_val, float b_val) {
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x) {
+                float dx = float(x) - cx, dy = float(y) - cy;
+                if (dx*dx + dy*dy < r*r)
+                    img.set3(x, y, r_val, g_val, b_val);
+            }
+    };
+
+    circle(w * 0.20f, h * 0.25f, h * 0.12f, 10.0f,  8.0f, 5.0f);
+    circle(w * 0.65f, h * 0.40f, h * 0.08f,  4.0f,  6.0f, 4.0f);
+
+    return img;
+}
+
+// ---------------------------------------------------------------------------
+// "Old" binary-search sampler — reimplements the pre-alias-table CDF logic
+// using flat std::vectors (slightly faster than the original Texture-based
+// approach, so this is generous to the old code)
+// ---------------------------------------------------------------------------
+
+struct BinarySearchSampler
+{
+    int w = 0, h = 0;
+    std::vector<float> cumRows;  // h elements: normalized row CDF
+    std::vector<float> rowSums;  // w*h elements: per-row normalized CDFs
+    std::vector<float> pixelPdf; // w*h elements: precomputed PDF
+
+    void build(const Image<float> & img)
+    {
+        w = int(img.width);
+        h = int(img.height);
+        cumRows.resize(h);
+        rowSums.resize(w * h);
+        pixelPdf.resize(w * h);
+
+        float totalCumVal = 0.0f;
+        for (int y = 0; y < h; ++y) {
+            float cosEl = std::cos(lerpFromTo<float>(float(y) + 0.5f, 0.0f, float(h),
+                                                     -float(constants::PI_OVER_TWO),
+                                                      float(constants::PI_OVER_TWO)));
+            float rowCumVal = 0.0f;
+            for (int x = 0; x < w; ++x) {
+                float value    = img.channelSum(x, y);
+                rowCumVal     += value * float(constants::TWO_PI);
+                pixelPdf[y*w + x] = value;
+                rowSums [y*w + x] = rowCumVal;
+            }
+            totalCumVal += rowCumVal * cosEl;
+            cumRows[y]   = totalCumVal;
+
+            if (rowCumVal > 0.0f)
+                for (int x = 0; x < w; ++x)
+                    rowSums[y*w + x] /= rowCumVal;
+        }
+        if (totalCumVal > 0.0f)
+            for (int y = 0; y < h; ++y)
+                cumRows[y] /= totalCumVal;
+
+        float pdfSum = 0.0f;
+        for (float v : pixelPdf) pdfSum += v;
+        float invPdfNorm = (pdfSum > 0.0f) ? 1.0f / (pdfSum * float(constants::FOUR_PI)) : 0.0f;
+        for (float & v : pixelPdf) v *= invPdfNorm;
+    }
+
+    // Returns the sampled PDF; mirrors the original importanceSample() return value
+    float sample(float e1, float e2) const
+    {
+        // Binary search for row
+        int y1 = 0, y2 = h - 1, y = (y1 + y2) / 2;
+        while (y1 < y2) {
+            if (cumRows[y] > e2) y2 = y;
+            else                  y1 = y + 1;
+            y = (y1 + y2) / 2;
+        }
+
+        // Binary search for column in selected row
+        int x1 = 0, x2 = w - 1, x = (x1 + x2) / 2;
+        while (x1 < x2) {
+            if (rowSums[y*w + x] > e1) x2 = x;
+            else                         x1 = x + 1;
+            x = (x1 + x2) / 2;
+        }
+
+        return pixelPdf[y*w + x] * float(w * h);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Global fixture — built once, shared across all benchmarks
+// ---------------------------------------------------------------------------
+
+struct Fixture
+{
+    static constexpr int W = 1024;
+    static constexpr int H = 512;
+
+    Image<float>          img;
+    BinarySearchSampler   bss;
+    LatLonEnvironmentMap  latlon;
+
+    Fixture()
+        : img(makeSyntheticEnvMap(W, H))
+    {
+        bss.build(img);
+        latlon.loadFromImage(img);
+    }
+};
+
+static Fixture * g_fixture = nullptr;
+
+// ---------------------------------------------------------------------------
+// BM1: importanceSample only — binary search vs alias table
+//      Tests the core CDF/alias lookup in isolation (no direction, no radiance)
+// ---------------------------------------------------------------------------
+
+static void BM_BinarySearch_ImportanceSample(benchmark::State & state)
+{
+    const BinarySearchSampler & bss = g_fixture->bss;
+    RNG rng;
+    for (auto _ : state) {
+        vec2 e   = rng.uniform2DRange01();
+        float pdf = bss.sample(e.x, e.y);
+        benchmark::DoNotOptimize(pdf);
+    }
+}
+BENCHMARK(BM_BinarySearch_ImportanceSample);
+
+static void BM_AliasTable_ImportanceSample(benchmark::State & state)
+{
+    LatLonEnvironmentMap & latlon = g_fixture->latlon;
+    RNG rng;
+    float pdf;
+    for (auto _ : state) {
+        vec2 e    = rng.uniform2DRange01();
+        vec2 coord = latlon.importanceSample(e.x, e.y, pdf);
+        benchmark::DoNotOptimize(coord);
+        benchmark::DoNotOptimize(pdf);
+    }
+}
+BENCHMARK(BM_AliasTable_ImportanceSample);
+
+// ---------------------------------------------------------------------------
+// BM2: full sampling path — direction + radiance
+//      "Old" = binary search + pixel→trig→direction + sampleRay(atan2/acos/bilinear)
+//      "New" = alias table + importanceSampleFull (direct pixel fetch)
+// ---------------------------------------------------------------------------
+
+static void BM_BinarySearch_Full(benchmark::State & state)
+{
+    const BinarySearchSampler & bss    = g_fixture->bss;
+    LatLonEnvironmentMap &      latlon = g_fixture->latlon;
+    const float PI     = float(constants::PI);
+    const float TWO_PI = float(constants::TWO_PI);
+    const int   W = bss.w, H = bss.h;
+    RNG rng;
+
+    for (auto _ : state) {
+        vec2 e = rng.uniform2DRange01();
+
+        // Binary search for (x, y)
+        int y1 = 0, y2 = H-1, y = (y1+y2)/2;
+        while (y1 < y2) {
+            if (bss.cumRows[y] > e.y) y2 = y; else y1 = y+1;
+            y = (y1+y2)/2;
+        }
+        int x1 = 0, x2 = W-1, x = (x1+x2)/2;
+        while (x1 < x2) {
+            if (bss.rowSums[y*W + x] > e.x) x2 = x; else x1 = x+1;
+            x = (x1+x2)/2;
+        }
+        float pdf = bss.pixelPdf[y*W + x] * float(W*H);
+
+        // Old direction path: pixel center → spherical → Cartesian
+        float u     = (float(x) + 0.5f) / float(W);
+        float v     = (float(y) + 0.5f) / float(H);
+        float phi   = u * TWO_PI - PI;
+        float theta = v * PI;
+        float sinT  = std::sin(theta);
+        Direction3 dir { std::sin(phi)*sinT, std::cos(theta), -std::cos(phi)*sinT };
+
+        // Old radiance path: direction → atan2/acos → bilinear texture lookup
+        Ray ray{ Position3(0.0f, 0.0f, 0.0f), dir };
+        RadianceRGB rad = latlon.sampleRay(ray);
+
+        benchmark::DoNotOptimize(pdf);
+        benchmark::DoNotOptimize(dir);
+        benchmark::DoNotOptimize(rad);
+    }
+}
+BENCHMARK(BM_BinarySearch_Full);
+
+static void BM_AliasTable_Full(benchmark::State & state)
+{
+    LatLonEnvironmentMap & latlon = g_fixture->latlon;
+    RNG rng;
+    for (auto _ : state) {
+        vec2 e              = rng.uniform2DRange01();
+        EnvironmentMapSample s = latlon.importanceSampleFull(e.x, e.y);
+        benchmark::DoNotOptimize(s);
+    }
+}
+BENCHMARK(BM_AliasTable_Full);
+
+// ---------------------------------------------------------------------------
+
+int main(int argc, char ** argv)
+{
+    Fixture fixture;
+    g_fixture = &fixture;
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+    return 0;
+}

--- a/benchmarks/envmap_sampling.cpp
+++ b/benchmarks/envmap_sampling.cpp
@@ -1,7 +1,6 @@
 #include <benchmark/benchmark.h>
 #include <vector>
 #include <cmath>
-#include <algorithm>
 
 #include "image.h"
 #include "LatLonEnvironmentMap.h"
@@ -36,79 +35,6 @@ static Image<float> makeSyntheticEnvMap(int w, int h)
 }
 
 // ---------------------------------------------------------------------------
-// "Old" binary-search sampler — reimplements the pre-alias-table CDF logic
-// using flat std::vectors (slightly faster than the original Texture-based
-// approach, so this is generous to the old code)
-// ---------------------------------------------------------------------------
-
-struct BinarySearchSampler
-{
-    int w = 0, h = 0;
-    std::vector<float> cumRows;  // h elements: normalized row CDF
-    std::vector<float> rowSums;  // w*h elements: per-row normalized CDFs
-    std::vector<float> pixelPdf; // w*h elements: precomputed PDF
-
-    void build(const Image<float> & img)
-    {
-        w = int(img.width);
-        h = int(img.height);
-        cumRows.resize(h);
-        rowSums.resize(w * h);
-        pixelPdf.resize(w * h);
-
-        float totalCumVal = 0.0f;
-        for (int y = 0; y < h; ++y) {
-            float cosEl = std::cos(lerpFromTo<float>(float(y) + 0.5f, 0.0f, float(h),
-                                                     -float(constants::PI_OVER_TWO),
-                                                      float(constants::PI_OVER_TWO)));
-            float rowCumVal = 0.0f;
-            for (int x = 0; x < w; ++x) {
-                float value    = img.channelSum(x, y);
-                rowCumVal     += value * float(constants::TWO_PI);
-                pixelPdf[y*w + x] = value;
-                rowSums [y*w + x] = rowCumVal;
-            }
-            totalCumVal += rowCumVal * cosEl;
-            cumRows[y]   = totalCumVal;
-
-            if (rowCumVal > 0.0f)
-                for (int x = 0; x < w; ++x)
-                    rowSums[y*w + x] /= rowCumVal;
-        }
-        if (totalCumVal > 0.0f)
-            for (int y = 0; y < h; ++y)
-                cumRows[y] /= totalCumVal;
-
-        float pdfSum = 0.0f;
-        for (float v : pixelPdf) pdfSum += v;
-        float invPdfNorm = (pdfSum > 0.0f) ? 1.0f / (pdfSum * float(constants::FOUR_PI)) : 0.0f;
-        for (float & v : pixelPdf) v *= invPdfNorm;
-    }
-
-    // Returns the sampled PDF; mirrors the original importanceSample() return value
-    float sample(float e1, float e2) const
-    {
-        // Binary search for row
-        int y1 = 0, y2 = h - 1, y = (y1 + y2) / 2;
-        while (y1 < y2) {
-            if (cumRows[y] > e2) y2 = y;
-            else                  y1 = y + 1;
-            y = (y1 + y2) / 2;
-        }
-
-        // Binary search for column in selected row
-        int x1 = 0, x2 = w - 1, x = (x1 + x2) / 2;
-        while (x1 < x2) {
-            if (rowSums[y*w + x] > e1) x2 = x;
-            else                         x1 = x + 1;
-            x = (x1 + x2) / 2;
-        }
-
-        return pixelPdf[y*w + x] * float(w * h);
-    }
-};
-
-// ---------------------------------------------------------------------------
 // Global fixture — built once, shared across all benchmarks
 // ---------------------------------------------------------------------------
 
@@ -117,14 +43,12 @@ struct Fixture
     static constexpr int W = 1024;
     static constexpr int H = 512;
 
-    Image<float>          img;
-    BinarySearchSampler   bss;
-    LatLonEnvironmentMap  latlon;
+    Image<float>         img;
+    LatLonEnvironmentMap latlon;
 
     Fixture()
         : img(makeSyntheticEnvMap(W, H))
     {
-        bss.build(img);
         latlon.loadFromImage(img);
     }
 };
@@ -132,87 +56,54 @@ struct Fixture
 static Fixture * g_fixture = nullptr;
 
 // ---------------------------------------------------------------------------
-// BM1: importanceSample only — binary search vs alias table
-//      Tests the core CDF/alias lookup in isolation (no direction, no radiance)
+// BM_ImportanceSample: binary search lookup in isolation
 // ---------------------------------------------------------------------------
 
-static void BM_BinarySearch_ImportanceSample(benchmark::State & state)
-{
-    const BinarySearchSampler & bss = g_fixture->bss;
-    RNG rng;
-    for (auto _ : state) {
-        vec2 e   = rng.uniform2DRange01();
-        float pdf = bss.sample(e.x, e.y);
-        benchmark::DoNotOptimize(pdf);
-    }
-}
-BENCHMARK(BM_BinarySearch_ImportanceSample);
-
-static void BM_AliasTable_ImportanceSample(benchmark::State & state)
+static void BM_ImportanceSample(benchmark::State & state)
 {
     LatLonEnvironmentMap & latlon = g_fixture->latlon;
     RNG rng;
     float pdf;
     for (auto _ : state) {
-        vec2 e    = rng.uniform2DRange01();
+        vec2 e     = rng.uniform2DRange01();
         vec2 coord = latlon.importanceSample(e.x, e.y, pdf);
         benchmark::DoNotOptimize(coord);
         benchmark::DoNotOptimize(pdf);
     }
 }
-BENCHMARK(BM_AliasTable_ImportanceSample);
+BENCHMARK(BM_ImportanceSample);
 
 // ---------------------------------------------------------------------------
-// BM2: full sampling path — direction + radiance
-//      "Old" = binary search + pixel→trig→direction + sampleRay(atan2/acos/bilinear)
-//      "New" = alias table + importanceSampleFull (direct pixel fetch)
+// BM_Full_OldPath: binary search + direction + sampleRay (atan2/acos/bilinear)
+//   Approximates what importanceSampleDirection + sampleRay cost together
 // ---------------------------------------------------------------------------
 
-static void BM_BinarySearch_Full(benchmark::State & state)
+static void BM_Full_OldPath(benchmark::State & state)
 {
-    const BinarySearchSampler & bss    = g_fixture->bss;
-    LatLonEnvironmentMap &      latlon = g_fixture->latlon;
-    const float PI     = float(constants::PI);
-    const float TWO_PI = float(constants::TWO_PI);
-    const int   W = bss.w, H = bss.h;
+    LatLonEnvironmentMap & latlon = g_fixture->latlon;
     RNG rng;
-
     for (auto _ : state) {
         vec2 e = rng.uniform2DRange01();
 
-        // Binary search for (x, y)
-        int y1 = 0, y2 = H-1, y = (y1+y2)/2;
-        while (y1 < y2) {
-            if (bss.cumRows[y] > e.y) y2 = y; else y1 = y+1;
-            y = (y1+y2)/2;
-        }
-        int x1 = 0, x2 = W-1, x = (x1+x2)/2;
-        while (x1 < x2) {
-            if (bss.rowSums[y*W + x] > e.x) x2 = x; else x1 = x+1;
-            x = (x1+x2)/2;
-        }
-        float pdf = bss.pixelPdf[y*W + x] * float(W*H);
+        // Same work as importanceSampleDirection
+        RandomDirection d = latlon.importanceSampleDirection(e.x, e.y);
 
-        // Old direction path: pixel center → spherical → Cartesian
-        float u     = (float(x) + 0.5f) / float(W);
-        float v     = (float(y) + 0.5f) / float(H);
-        float phi   = u * TWO_PI - PI;
-        float theta = v * PI;
-        float sinT  = std::sin(theta);
-        Direction3 dir { std::sin(phi)*sinT, std::cos(theta), -std::cos(phi)*sinT };
-
-        // Old radiance path: direction → atan2/acos → bilinear texture lookup
-        Ray ray{ Position3(0.0f, 0.0f, 0.0f), dir };
+        // Then sampleRay: direction -> atan2/acos -> bilinear lookup
+        Ray ray{ Position3(0.0f, 0.0f, 0.0f), d.direction };
         RadianceRGB rad = latlon.sampleRay(ray);
 
-        benchmark::DoNotOptimize(pdf);
-        benchmark::DoNotOptimize(dir);
+        benchmark::DoNotOptimize(d);
         benchmark::DoNotOptimize(rad);
     }
 }
-BENCHMARK(BM_BinarySearch_Full);
+BENCHMARK(BM_Full_OldPath);
 
-static void BM_AliasTable_Full(benchmark::State & state)
+// ---------------------------------------------------------------------------
+// BM_Full_NewPath: binary search + direction + direct pixel fetch
+//   importanceSampleFull combines all three steps without the round-trip
+// ---------------------------------------------------------------------------
+
+static void BM_Full_NewPath(benchmark::State & state)
 {
     LatLonEnvironmentMap & latlon = g_fixture->latlon;
     RNG rng;
@@ -222,7 +113,7 @@ static void BM_AliasTable_Full(benchmark::State & state)
         benchmark::DoNotOptimize(s);
     }
 }
-BENCHMARK(BM_AliasTable_Full);
+BENCHMARK(BM_Full_NewPath);
 
 // ---------------------------------------------------------------------------
 

--- a/src/CubeMapEnvironmentMap.cpp
+++ b/src/CubeMapEnvironmentMap.cpp
@@ -41,7 +41,7 @@ void CubeMapEnvironmentMap::loadFromDirectionFiles(
 // Reference: https://en.wikipedia.org/wiki/Cube_mapping
 void CubeMapEnvironmentMap::directionToTileCoord(const Direction3 & v,
                                                  TexturePtr & texture,
-                                                 TextureCoordinate & texcoord)
+                                                 TextureCoordinate & texcoord) const
 {
     float absX = std::abs(v.x);
     float absY = std::abs(v.y);
@@ -110,7 +110,7 @@ void CubeMapEnvironmentMap::directionToTileCoord(const Direction3 & v,
     texcoord.v = -texcoord.v;
 }
 
-RadianceRGB CubeMapEnvironmentMap::sampleRay(const Ray & ray)
+RadianceRGB CubeMapEnvironmentMap::sampleRay(const Ray & ray) const
 {
     TexturePtr texture;
     TextureCoordinate texcoord;

--- a/src/CubeMapEnvironmentMap.h
+++ b/src/CubeMapEnvironmentMap.h
@@ -16,7 +16,7 @@ class CubeMapEnvironmentMap : public EnvironmentMap
                                     const std::string & negz,
                                     const std::string & posz);
 
-        RadianceRGB sampleRay(const Ray & ray) override;
+        RadianceRGB sampleRay(const Ray & ray) const override;
 
         void setScaleFactor(float f) { scaleFactor = f; }
 
@@ -25,7 +25,7 @@ class CubeMapEnvironmentMap : public EnvironmentMap
 
         void directionToTileCoord(const Direction3 & v,
                                   TexturePtr & texture,
-                                  TextureCoordinate & texcoord);
+                                  TextureCoordinate & texcoord) const;
 
         TexturePtr xn;
         TexturePtr xp;

--- a/src/EnvironmentMap.cpp
+++ b/src/EnvironmentMap.cpp
@@ -1,8 +1,16 @@
 #include "EnvironmentMap.h"
+#include "Ray.h"
 
-RadianceRGB EnvironmentMap::sampleRay(const Ray & ray)
+RadianceRGB EnvironmentMap::sampleRay(const Ray & ray) const
 {
     return RadianceRGB();
+}
+
+EnvironmentMapSample EnvironmentMap::importanceSampleFull(float e1, float e2) const
+{
+    RandomDirection d = importanceSampleDirection(e1, e2);
+    Ray r{ Position3(0.0f, 0.0f, 0.0f), d.direction };
+    return { d.direction, d.pdf, sampleRay(r) };
 }
 
 std::string EnvironmentMap::lookupPath(const std::string & fileName)

--- a/src/EnvironmentMap.h
+++ b/src/EnvironmentMap.h
@@ -14,17 +14,25 @@ struct RandomDirection {
     float pdf;
 };
 
+struct EnvironmentMapSample {
+    Direction3  direction;
+    float       pdf;
+    RadianceRGB radiance;
+};
+
 class EnvironmentMap
 {
     public:
         EnvironmentMap() = default;
         virtual ~EnvironmentMap() = default;
 
-        virtual RadianceRGB sampleRay(const Ray & ray);
+        virtual RadianceRGB sampleRay(const Ray & ray) const;
 
         // Importance sampling
         virtual vec2 importanceSample(float e1, float e2, float & pdf) const { pdf = 0.0f; return vec2(0.0f, 0.0f); }
         virtual RandomDirection importanceSampleDirection(float e1, float e2) const { return { Direction3(0.0f, 0.0f, 0.0f), 0.0f }; }
+        // Returns direction, PDF, and radiance in one call — avoids redundant coordinate transforms
+        virtual EnvironmentMapSample importanceSampleFull(float e1, float e2) const;
         virtual bool canImportanceSample() const { return false; }
 
         virtual void saveDebugImages() {};

--- a/src/GradientEnvironmentMap.cpp
+++ b/src/GradientEnvironmentMap.cpp
@@ -21,7 +21,7 @@ GradientEnvironmentMap::GradientEnvironmentMap(const RadianceRGB & low,
 
 }
 
-RadianceRGB GradientEnvironmentMap::sampleRay(const Ray & ray)
+RadianceRGB GradientEnvironmentMap::sampleRay(const Ray & ray) const
 {
     // [-1, 1] assuming ray.direction is normalized
     float a = dot(ray.direction, direction);

--- a/src/GradientEnvironmentMap.h
+++ b/src/GradientEnvironmentMap.h
@@ -12,7 +12,7 @@ class GradientEnvironmentMap : public EnvironmentMap
                                const RadianceRGB & high,
                                const Direction3 & direction);
 
-        RadianceRGB sampleRay(const Ray & ray) override;
+        RadianceRGB sampleRay(const Ray & ray) const override;
 
     protected:
         RadianceRGB low;

--- a/src/LatLonEnvironmentMap.cpp
+++ b/src/LatLonEnvironmentMap.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <vector>
 #include "constants.h"
 #include "LatLonEnvironmentMap.h"
 #include "Ray.h"
@@ -56,98 +55,101 @@ RadianceRGB LatLonEnvironmentMap::sampleRay(const Ray & ray) const
 
 void LatLonEnvironmentMap::buildImportanceSampleLookup()
 {
-    const int w = texture->width, h = texture->height;
-    const int N = w * h;
+    int w = texture->width, h = texture->height;
 
-    // Compute per-pixel sampling weights (cosine-elevation-weighted luminance)
-    // and raw luminance sum for PDF normalization.
-    // cosElevation corrects for the area distortion of the lat/lon projection:
-    // pixels near the poles cover less solid angle and are down-weighted.
-    std::vector<float> weights(N);
-    float pdfSum     = 0.0f;
-    float totalWeight = 0.0f;
+    rowSums = std::make_shared<Texture>(w, h, 1);
+    cumRows.resize(texture->height);
+    pdf2D = std::make_shared<Texture>(w, h, 1);
+
+    float totalCumVal = 0.0f;
 
     for(int y = 0; y < h; ++y) {
-        float cosEl = std::cos(lerpFromTo<float>(float(y) + 0.5f, 0.0f, float(h),
+        // Weight by the cosine of the elevation angle to account for
+        // area distortion in a flattened lat/lon representation
+        float cosEl = std::cos(lerpFromTo<float>(float(y)+0.5f, 0.0f, float(h),
                                                  -constants::PI_OVER_TWO, constants::PI_OVER_TWO));
+        // Compute cumulative sums for each row
+        float rowCumVal = 0.0f;
         for(int x = 0; x < w; ++x) {
-            float lum    = texture->channelSum(x, y);
-            float weight = lum * cosEl * float(constants::TWO_PI);
-            weights[y * w + x] = weight;
-            pdfSum      += lum;
-            totalWeight += weight;
+            float value = texture->channelSum(x, y);
+            rowCumVal += value * constants::TWO_PI;
+            pdf2D->set(x, y, 0, value);
+            rowSums->set(x, y, 0, rowCumVal);
+        }
+        totalCumVal += rowCumVal * cosEl;
+        cumRows[y] = totalCumVal;
+
+        // Normalize PDFs and CDFs to [0, 1]
+        if(rowCumVal > 0.0f) {
+            for(int x = 0; x < w; ++x) {
+                rowSums->set(x, y, 0, rowSums->get(x, y, 0) / rowCumVal);
+            }
+        }
+    }
+    // Normalize cumulative row sums to [0, 1]
+    if(totalCumVal > 0.0f) {
+        for(int y = 0; y < h; ++y) {
+            cumRows[y] /= totalCumVal;
         }
     }
 
-    // PDF normalization factor — matches the convention used in the original code:
-    //   pdf(x,y) = channelSum(x,y) / pdfSum / FOUR_PI * (w * h)
-    pdfNormFactor = (pdfSum > 0.0f)
-        ? float(N) / pdfSum / float(constants::FOUR_PI)
-        : 0.0f;
+    float pdfSum = 0.0f;
+    pdf2D->forEachPixel([&pdfSum](Image<float> & img, size_t x, size_t y) {
+                    pdfSum += img.get(x, y, 0); });
 
-    // Build Walker alias table from the cosine-weighted sampling distribution.
-    // Construction runs once at load time; each sample costs 2 array lookups + 1 compare.
-    aliasProb.assign(N, 1.0f);
-    aliasIdx.assign(N, 0);
-
-    // Scale weights so the average is 1.0
-    const float invTotal = (totalWeight > 0.0f) ? float(N) / totalWeight : 0.0f;
-    std::vector<float> scaled(N);
-    for(int i = 0; i < N; ++i) {
-        scaled[i] = weights[i] * invTotal;
+    // Normalize the PDF
+    for(int y = 0; y < h; ++y) {
+        for(int x = 0; x < w; ++x) {
+            pdf2D->set(x, y, 0, pdf2D->get(x, y, 0) / pdfSum / constants::FOUR_PI);
+        }
     }
-
-    // Vose's O(n) alias table construction
-    std::vector<int> small, large;
-    small.reserve(N);
-    large.reserve(N);
-    for(int i = 0; i < N; ++i) {
-        if(scaled[i] < 1.0f) small.push_back(i);
-        else                  large.push_back(i);
-    }
-    while(!small.empty() && !large.empty()) {
-        int l = small.back(); small.pop_back();
-        int g = large.back(); large.pop_back();
-        aliasProb[l] = scaled[l];
-        aliasIdx[l]  = uint32_t(g);
-        scaled[g]    = (scaled[g] + scaled[l]) - 1.0f;
-        if(scaled[g] < 1.0f) small.push_back(g);
-        else                  large.push_back(g);
-    }
-    // Any remaining entries have probability 1 (already set by assign above)
 }
 
 vec2 LatLonEnvironmentMap::importanceSample(float e1, float e2, float & pdf) const
 {
-    const int N = int(aliasProb.size());
-    const int i   = std::min(int(e1 * float(N)), N - 1);
-    const int idx = (e2 < aliasProb[i]) ? i : int(aliasIdx[i]);
+    const int w = texture->width, h = texture->height;
 
-    const int x = idx % texture->width;
-    const int y = idx / texture->width;
+    // Binary search for y using row sums
+    int y1 = 0, y2 = h - 1;
+    int y = (y1 + y2) / 2;
 
-    pdf = texture->channelSum(x, y) * pdfNormFactor;
+    while(y1 < y2) {
+        float value = cumRows[y];
+        if(value > e2) { y2 = y; }
+        else           { y1 = y + 1; }
+        y = (y1 + y2) / 2;
+    }
+
+    // Binary search for x in row given by y
+    int x1 = 0, x2 = w - 1;
+    int x = (x1 + x2) / 2;
+
+    while(x1 < x2) {
+        float value = rowSums->get(x, y, 0);
+        if(value > e1) { x2 = x; }
+        else           { x1 = x + 1; }
+        x = (x1 + x2) / 2;
+    }
+
+    pdf = pdf2D->get(x, y, 0) * w * h;
     return { float(x) + 0.5f, float(y) + 0.5f };
 }
 
 EnvironmentMapSample LatLonEnvironmentMap::importanceSampleFull(float e1, float e2) const
 {
-    const int N = int(aliasProb.size());
-    const int i   = std::min(int(e1 * float(N)), N - 1);
-    const int idx = (e2 < aliasProb[i]) ? i : int(aliasIdx[i]);
+    float pdf;
+    vec2 pixel = importanceSample(e1, e2, pdf);
 
-    const int x = idx % texture->width;
-    const int y = idx / texture->width;
+    const int x = int(pixel.x);
+    const int y = int(pixel.y);
 
-    const float pdf = texture->channelSum(x, y) * pdfNormFactor;
-
-    // Convert pixel center to a spherical direction — same mapping as sampleRay's inverse
+    // Convert pixel center to spherical direction
     const float PI     = float(constants::PI);
     const float TWO_PI = float(constants::TWO_PI);
-    const float u     = (float(x) + 0.5f) / float(texture->width);
-    const float v     = (float(y) + 0.5f) / float(texture->height);
-    const float phi   = u * TWO_PI - PI;
-    const float theta = v * PI;
+    const float u      = pixel.x / float(texture->width);
+    const float v      = pixel.y / float(texture->height);
+    const float phi    = u * TWO_PI - PI;
+    const float theta  = v * PI;
     const float sinTheta = std::sin(theta);
     const Direction3 dir {
         std::sin(phi) * sinTheta,
@@ -155,7 +157,7 @@ EnvironmentMapSample LatLonEnvironmentMap::importanceSampleFull(float e1, float 
         -std::cos(phi) * sinTheta
     };
 
-    // Direct pixel fetch — no round-trip coordinate transform needed
+    // Direct pixel fetch — skips the atan2/acos/bilinear round-trip of sampleRay
     const RadianceRGB rad {
         scaleFactor * texture->get(x, y, 0),
         scaleFactor * texture->get(x, y, 1),
@@ -173,14 +175,7 @@ RandomDirection LatLonEnvironmentMap::importanceSampleDirection(float e1, float 
 
 void LatLonEnvironmentMap::saveDebugImages()
 {
-    const int w = texture->width, h = texture->height;
-
     writePNG(*texture, "envmap_texture.png");
-
-    // Reconstruct a PDF image for visualization
-    Texture pdfTex(w, h, 1);
-    for(int y = 0; y < h; ++y)
-        for(int x = 0; x < w; ++x)
-            pdfTex.set(x, y, 0, texture->channelSum(x, y) * pdfNormFactor);
-    writePNG(applyGamma(pdfTex, 1.0/10.0), "envmap_pdf.png");
+    writePNG(*rowSums, "envmap_rowsums.png");
+    writePNG(applyGamma(*pdf2D, 1.0/10.0), "envmap_pdf.png");
 }

--- a/src/LatLonEnvironmentMap.cpp
+++ b/src/LatLonEnvironmentMap.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <vector>
 #include "constants.h"
 #include "LatLonEnvironmentMap.h"
 #include "Ray.h"
@@ -34,7 +35,7 @@ void LatLonEnvironmentMap::loadFromImage(const Image<float> & image)
     buildImportanceSampleLookup();
 }
 
-RadianceRGB LatLonEnvironmentMap::sampleRay(const Ray & ray)
+RadianceRGB LatLonEnvironmentMap::sampleRay(const Ray & ray) const
 {
     auto & D = ray.direction;
 
@@ -55,155 +56,131 @@ RadianceRGB LatLonEnvironmentMap::sampleRay(const Ray & ray)
 
 void LatLonEnvironmentMap::buildImportanceSampleLookup()
 {
-    int w = texture->width, h = texture->height;
+    const int w = texture->width, h = texture->height;
+    const int N = w * h;
 
-    rowSums = std::make_shared<Texture>(w, h, 1);
-    cumRows.resize(texture->height);
-    pdf2D = std::make_shared<Texture>(w, h, 1);
+    // Compute per-pixel sampling weights (cosine-elevation-weighted luminance)
+    // and raw luminance sum for PDF normalization.
+    // cosElevation corrects for the area distortion of the lat/lon projection:
+    // pixels near the poles cover less solid angle and are down-weighted.
+    std::vector<float> weights(N);
+    float pdfSum     = 0.0f;
+    float totalWeight = 0.0f;
 
-    float totalCumVal = 0.0f;
-    
     for(int y = 0; y < h; ++y) {
-        // Weight by the cosine of the elevation angle to account for
-        // area distortion in a flattened lat/lon representation
-        //float cosEl = std::cos(lerpFromTo<float>(float(y)+0.5f, 0.0f, float(h)+0.5f,
-        float cosEl = std::cos(lerpFromTo<float>(float(y)+0.5f, 0.0f, float(h),
+        float cosEl = std::cos(lerpFromTo<float>(float(y) + 0.5f, 0.0f, float(h),
                                                  -constants::PI_OVER_TWO, constants::PI_OVER_TWO));
-        // Compute cumulative sums for each row
-        float rowCumVal = 0.0f;
         for(int x = 0; x < w; ++x) {
-            float value = texture->channelSum(x, y);
-            rowCumVal += value * constants::TWO_PI;
-            pdf2D->set(x, y, 0, value);
-            rowSums->set(x, y, 0, rowCumVal);
-        }
-        totalCumVal += rowCumVal * cosEl;
-        cumRows[y] = totalCumVal;
-
-        // Normalize PDFs and CDFs to [0, 1]
-        if(rowCumVal > 0.0f) {
-            for(int x = 0; x < w; ++x) {
-                rowSums->set(x, y, 0, rowSums->get(x, y, 0) / rowCumVal);
-            }
-        }
-    }
-    // Normalize cumulative row sums to [0, 1]
-    if(totalCumVal > 0.0f) {
-        for(int y = 0; y < h; ++y) {
-            cumRows[y] /= totalCumVal;
+            float lum    = texture->channelSum(x, y);
+            float weight = lum * cosEl * float(constants::TWO_PI);
+            weights[y * w + x] = weight;
+            pdfSum      += lum;
+            totalWeight += weight;
         }
     }
 
-    float pdfSum = 0.0f;
-    pdf2D->forEachPixel([&pdfSum](Image<float> & img, size_t x, size_t y) {
-                    pdfSum += img.get(x, y, 0); });
+    // PDF normalization factor — matches the convention used in the original code:
+    //   pdf(x,y) = channelSum(x,y) / pdfSum / FOUR_PI * (w * h)
+    pdfNormFactor = (pdfSum > 0.0f)
+        ? float(N) / pdfSum / float(constants::FOUR_PI)
+        : 0.0f;
 
-    // Normalize the PDF
-    for(int y = 0; y < h; ++y) {
-        for(int x = 0; x < w; ++x) {
-            pdf2D->set(x, y, 0, pdf2D->get(x, y, 0) / pdfSum / constants::FOUR_PI);
-        }
+    // Build Walker alias table from the cosine-weighted sampling distribution.
+    // Construction runs once at load time; each sample costs 2 array lookups + 1 compare.
+    aliasProb.assign(N, 1.0f);
+    aliasIdx.assign(N, 0);
+
+    // Scale weights so the average is 1.0
+    const float invTotal = (totalWeight > 0.0f) ? float(N) / totalWeight : 0.0f;
+    std::vector<float> scaled(N);
+    for(int i = 0; i < N; ++i) {
+        scaled[i] = weights[i] * invTotal;
     }
+
+    // Vose's O(n) alias table construction
+    std::vector<int> small, large;
+    small.reserve(N);
+    large.reserve(N);
+    for(int i = 0; i < N; ++i) {
+        if(scaled[i] < 1.0f) small.push_back(i);
+        else                  large.push_back(i);
+    }
+    while(!small.empty() && !large.empty()) {
+        int l = small.back(); small.pop_back();
+        int g = large.back(); large.pop_back();
+        aliasProb[l] = scaled[l];
+        aliasIdx[l]  = uint32_t(g);
+        scaled[g]    = (scaled[g] + scaled[l]) - 1.0f;
+        if(scaled[g] < 1.0f) small.push_back(g);
+        else                  large.push_back(g);
+    }
+    // Any remaining entries have probability 1 (already set by assign above)
 }
 
 vec2 LatLonEnvironmentMap::importanceSample(float e1, float e2, float & pdf) const
 {
-    const int w = texture->width, h = texture->height;
+    const int N = int(aliasProb.size());
+    const int i   = std::min(int(e1 * float(N)), N - 1);
+    const int idx = (e2 < aliasProb[i]) ? i : int(aliasIdx[i]);
 
-#if 0  // WORKING
-    // Linear search y using row sums
-    int y;
-    for(y = 0; y < h - 1; ++y) {
-        if(cumRows[y] > e2)
-            break;
-    }
+    const int x = idx % texture->width;
+    const int y = idx / texture->width;
 
-    // Linear search for x in row given by y
-    int x;
-    for(x = 0; x < w - 1; ++x) {
-        if(rowSums->get(x, y, 0) > e1)
-            break;
-    }
-
-#else
-
-    // Binary search for y using row sums
-
-    int y1 = 0, y2 = h - 1;
-    //int y1 = 0, y2 = h;
-    int y = (y1 + y2) / 2;
-
-    while(y1 < y2) {
-        float value = cumRows[y];
-        if(value > e2) { y2 = y; }
-        else           { y1 = y + 1; }
-        y = (y1 + y2) / 2;
-    }
-
-    // Binary search for x in row given by y
-
-    int x1 = 0, x2 = w - 1;
-    int x = (x1 + x2) / 2;
-
-    while(x1 < x2) {
-        float value = rowSums->get(x, y, 0);
-        if(value > e1) { x2 = x; }
-        else           { x1 = x + 1; }
-        x = (x1 + x2) / 2;
-    }
-#endif
-
-    pdf = pdf2D->get(x, y, 0) * w * h;
-
-#if 0 // TODO: Seems okay, but needs more testing
-    // Grab some lower order bits of the random numbers and treat them
-    // as separate random numbers for subpixel sampling.
-    float sx = float(x), sy = float(y);
-    float shift = 2.0e4f;
-
-    float e3 = e1 * shift - floor(e1 * shift);
-    float e4 = e2 * shift - floor(e2 * shift);
-    //printf("e1 %f e2 %f : e3 %f e4 %f\n", e1, e2, e3, e4); // TEMP
-
-    sx += e3;
-    sy += e4;
-
-    return { sx, sy };
-#else
-    // No subpixel sampling
+    pdf = texture->channelSum(x, y) * pdfNormFactor;
     return { float(x) + 0.5f, float(y) + 0.5f };
-#endif
+}
+
+EnvironmentMapSample LatLonEnvironmentMap::importanceSampleFull(float e1, float e2) const
+{
+    const int N = int(aliasProb.size());
+    const int i   = std::min(int(e1 * float(N)), N - 1);
+    const int idx = (e2 < aliasProb[i]) ? i : int(aliasIdx[i]);
+
+    const int x = idx % texture->width;
+    const int y = idx / texture->width;
+
+    const float pdf = texture->channelSum(x, y) * pdfNormFactor;
+
+    // Convert pixel center to a spherical direction — same mapping as sampleRay's inverse
+    const float PI     = float(constants::PI);
+    const float TWO_PI = float(constants::TWO_PI);
+    const float u     = (float(x) + 0.5f) / float(texture->width);
+    const float v     = (float(y) + 0.5f) / float(texture->height);
+    const float phi   = u * TWO_PI - PI;
+    const float theta = v * PI;
+    const float sinTheta = std::sin(theta);
+    const Direction3 dir {
+        std::sin(phi) * sinTheta,
+        std::cos(theta),
+        -std::cos(phi) * sinTheta
+    };
+
+    // Direct pixel fetch — no round-trip coordinate transform needed
+    const RadianceRGB rad {
+        scaleFactor * texture->get(x, y, 0),
+        scaleFactor * texture->get(x, y, 1),
+        scaleFactor * texture->get(x, y, 2)
+    };
+
+    return { dir, pdf, rad };
 }
 
 RandomDirection LatLonEnvironmentMap::importanceSampleDirection(float e1, float e2) const
 {
-    float pdf = 0.0f;
-    vec2 pixel = importanceSample(e1, e2, pdf);
-    TextureCoordinate texcoord = {
-        pixel.x / float(texture->width),
-        pixel.y / float(texture->height)
-    };
-
-    float PI = float(constants::PI);
-    float TWO_PI = float(constants::TWO_PI);
-
-    float phi = texcoord.u * TWO_PI - PI;
-    float theta = texcoord.v * PI;
-
-    Direction3 dir{
-        std::sin(phi) * std::sin(theta),
-        std::cos(theta),
-        -std::cos(phi) * std::sin(theta)
-    };
-
-    return { dir, pdf };
+    auto s = importanceSampleFull(e1, e2);
+    return { s.direction, s.pdf };
 }
 
 void LatLonEnvironmentMap::saveDebugImages()
 {
-    writePNG(*texture, "envmap_texture.png");
-    writePNG(*rowSums, "envmap_rowsums.png");
-    writePNG(applyGamma(*pdf2D, 1.0/10.0), "envmap_pdf.png");
-    //writePNG(*pdf2D, "envmap_pdf.png");
-}
+    const int w = texture->width, h = texture->height;
 
+    writePNG(*texture, "envmap_texture.png");
+
+    // Reconstruct a PDF image for visualization
+    Texture pdfTex(w, h, 1);
+    for(int y = 0; y < h; ++y)
+        for(int x = 0; x < w; ++x)
+            pdfTex.set(x, y, 0, texture->channelSum(x, y) * pdfNormFactor);
+    writePNG(applyGamma(pdfTex, 1.0/10.0), "envmap_pdf.png");
+}

--- a/src/LatLonEnvironmentMap.h
+++ b/src/LatLonEnvironmentMap.h
@@ -32,10 +32,10 @@ class LatLonEnvironmentMap : public EnvironmentMap
 
         TexturePtr texture;
 
-        // Importance sampling via Walker alias table — O(1) per sample
-        std::vector<float>    aliasProb; // Acceptance probability for each pixel
-        std::vector<uint32_t> aliasIdx;  // Alias index for each pixel
-        float pdfNormFactor = 0.0f;      // Precomputed: N / pdfSum / FOUR_PI
+        // Importance sampling — PDFs/CDFs stored per row in textures
+        TexturePtr         rowSums; // Cumulative sums along rows (normalized per row)
+        std::vector<float> cumRows; // Cumulative sum of row sums (normalized)
+        TexturePtr         pdf2D;   // PDF per pixel
 
         float scaleFactor = 1.0f;
 

--- a/src/LatLonEnvironmentMap.h
+++ b/src/LatLonEnvironmentMap.h
@@ -12,7 +12,7 @@ class LatLonEnvironmentMap : public EnvironmentMap
         void loadFromFile(const std::string & filename);
         void loadFromImage(const Image<float> & image);
 
-        RadianceRGB sampleRay(const Ray & ray) override;
+        RadianceRGB sampleRay(const Ray & ray) const override;
 
         void setScaleFactor(float f) { scaleFactor = f; }
 
@@ -22,6 +22,7 @@ class LatLonEnvironmentMap : public EnvironmentMap
         // Returns pixel coordinate of index
         vec2 importanceSample(float e1, float e2, float & pdf) const override;
         RandomDirection importanceSampleDirection(float e1, float e2) const override;
+        EnvironmentMapSample importanceSampleFull(float e1, float e2) const override;
         bool canImportanceSample() const override { return true; }
 
         void saveDebugImages() override;
@@ -31,12 +32,10 @@ class LatLonEnvironmentMap : public EnvironmentMap
 
         TexturePtr texture;
 
-        // Importance sampling
-        //   PDFs/CDFs stored per row in textures
-        //   PDF/CDF of row aggregates
-        TexturePtr         rowSums; // Cumulative sums along rows
-        std::vector<float> cumRows; // Cumulative sum of row sums
-        TexturePtr         pdf2D;   // PDF
+        // Importance sampling via Walker alias table — O(1) per sample
+        std::vector<float>    aliasProb; // Acceptance probability for each pixel
+        std::vector<uint32_t> aliasIdx;  // Alias index for each pixel
+        float pdfNormFactor = 0.0f;      // Precomputed: N / pdfSum / FOUR_PI
 
         float scaleFactor = 1.0f;
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -510,20 +510,19 @@ inline RadianceRGB Renderer::sampleEnvironmentMap(
 
     // Importance sample environment map. Note, we do not draw another
     // sample if the sample is not visible, as doing so biases the estimate.
-    for(unsigned int envSample = 0; envSample < numSamples; ++envSample) {
+    for(unsigned int si = 0; si < numSamples; ++si) {
         vec2 e = rng.uniform2DRange01();
-        RandomDirection dirSample = scene.environmentMap->importanceSampleDirection(e.x, e.y);
-        float DdotN = dot(dirSample.direction, N);
-        
-        if(dirSample.pdf > 0.0f && DdotN > 0.0f) {
-            Ray ray{ P + N * epsilon, dirSample.direction };
+        EnvironmentMapSample s = scene.environmentMap->importanceSampleFull(e.x, e.y);
+        float DdotN = dot(s.direction, N);
+
+        if(s.pdf > 0.0f && DdotN > 0.0f) {
+            Ray ray{ P + N * epsilon, s.direction };
 
             bool hit = intersectsScene(scene, rng, ray, minDistance);
 
             if(!hit) {
-                float F = brdf.eval(Wo, dirSample.direction, N);
-                RadianceRGB Li = scene.environmentMap->sampleRay(ray); 
-                Lenv += F * DdotN * Li / dirSample.pdf;
+                float F = brdf.eval(Wo, s.direction, N);
+                Lenv += F * DdotN * s.radiance / s.pdf;
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Replace two-level binary search CDF with Walker alias table**: sampling goes from O(log w + log h) ≈ 20 iterations (with cache-unfriendly texture accesses) to O(1) — 2 array lookups + 1 comparison. The alias table is built once at load time from cosine-elevation-weighted pixel luminances, preserving the solid-angle-correct sampling distribution.
- **Eliminate coordinate round-trip in `sampleEnvironmentMap`**: the old path converted pixel (x,y) → trig → direction (`importanceSampleDirection`), then converted direction back → atan2/acos → bilinear lookup (`sampleRay`). The new `importanceSampleFull` returns direction + pdf + radiance together, fetching radiance directly from the texture at the already-known (x,y).
- **Memory**: roughly equivalent — `rowSums` (w×h texture) + `cumRows` (h-element vector) + `pdf2D` (w×h texture) replaced by `aliasProb` + `aliasIdx` (two flat w×h vectors) + one precomputed float `pdfNormFactor`. PDF convention is unchanged; renders are statistically identical.
- **Also**: propagated `sampleRay` `const`-correctness through all `EnvironmentMap` subclasses.

New virtual `EnvironmentMapSample importanceSampleFull(float e1, float e2) const` added to the base class with a default fallback. The existing `importanceSample` and `importanceSampleDirection` are preserved for backward compatibility (used by `tests/test_imp_samp_envmap.cpp`).

## Test plan

- [ ] All 19 unit tests pass (`ctest`)
- [ ] Visual inspection of a render using an HDR environment map — lighting should look the same as before
- [ ] Run `test_imp_samp_envmap` and verify sample distribution image looks correct (samples concentrated on bright regions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)