### PR TITLE
[claude] Use KD-tree accelerator for shadow ray intersection tests

### DIFF
--- a/src/scene.hpp
+++ b/src/scene.hpp
@@ -2,9 +2,16 @@
 inline bool intersectsWorldRay(const Ray & rayWorld, const Scene & scene,
                                float minDistance, float maxDistance)
 {
-    for(const auto & o : scene.objects) {
-        if(o->intersectsWorldRay(rayWorld, minDistance, maxDistance)) {
+    if(scene.useKDTreeAccelerator) {
+        if(scene.objectsKDTree.intersectsWorldRay(rayWorld, minDistance, maxDistance)) {
             return true;
+        }
+    }
+    else {
+        for(const auto & o : scene.objects) {
+            if(o->intersectsWorldRay(rayWorld, minDistance, maxDistance)) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `intersectsWorldRay()` in `scene.hpp` was always brute-forcing all scene objects even when `useKDTreeAccelerator` was true
- `findIntersectionWorldRay()` already had this KD-tree check, but the boolean version (used by `Renderer::intersectsScene()` for shadow rays) did not
- Shadow rays are cast for every light sample at every diffuse/specular hit, so this is a high-traffic path

## Test plan

- [x] Build succeeds
- [x] All 19 unit tests pass
- [ ] Render a scene with KD-tree enabled and verify shadow correctness matches brute-force

🤖 Generated with [Claude Code](https://claude.com/claude-code)