### PR TITLE
[claude] Fix typos, double semicolons, and minor code quality issues

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -371,7 +371,7 @@ inline LightSample Renderer::samplePointLight(const Scene & scene,
     const float lightDistSq = toLight.magnitude_sq();
     const float lightDist = std::sqrt(lightDistSq);
 
-    // Make sure the light is on the right size of the surface
+    // Make sure the light is on the right side of the surface
     if(dot(toLight, N) < 0.0f) {
         return S;
     }
@@ -426,7 +426,7 @@ inline LightSample Renderer::sampleDiskLight(const Scene & scene,
     S.L = RadianceRGB::BLACK();
     S.direction = toLight.normalized();
 
-    // Make sure the light is on the right size of the surface
+    // Make sure the light is on the right side of the surface
     if(dot(toLight, N) < 0.0f) {
         return S;
     }

--- a/src/TraceableKDTree.cpp
+++ b/src/TraceableKDTree.cpp
@@ -282,7 +282,7 @@ bool TraceableKDTree::findIntersectionNode(const KDNode & node, const Ray & ray,
         for(auto object : node.objects) {
             bool hit = object->findIntersectionWorldRay(ray, minDistance, tempIntersection);
             if(hit && (!anyHit || tempIntersection.distance < intersection.distance)) {
-                intersection = tempIntersection;;
+                intersection = tempIntersection;
                 anyHit = true;
             }
         }

--- a/src/TriangleMesh.cpp
+++ b/src/TriangleMesh.cpp
@@ -65,7 +65,7 @@ bool TriangleMesh::intersects(const Ray & ray, float minDistance, float maxDista
 
 bool TriangleMesh::findIntersection(const Ray & ray, float minDistance, RayIntersection & intersection) const
 {
-    float bestDistance = FLT_MAX, t = FLT_MAX;
+    float bestDistance = std::numeric_limits<float>::max(), t = std::numeric_limits<float>::max();
     uint32_t bestTriangle = 0;
     bool hit = false;
 

--- a/src/TriangleMeshOctree.cpp
+++ b/src/TriangleMeshOctree.cpp
@@ -321,7 +321,7 @@ bool TriangleMeshOctree::findIntersectionNodeTriangles(
     bool hit = false;
 
     if(node.numTriangles > 0) {
-        float t = FLT_MAX;
+        float t = std::numeric_limits<float>::max();
         assert(node.firstTriangle + node.numTriangles - 1 < triangles.size());
         for(uint32_t ti = 0; ti < node.numTriangles; ++ti) {
             auto tri = triangles[node.firstTriangle + ti];
@@ -348,7 +348,7 @@ bool TriangleMeshOctree::findIntersection(const Ray & ray, float minDistance,
     TriangleMeshOctree::child_array_t childOrder = {};
     std::stack<uint32_t> nodesToCheck;
     uint32_t bestTriangle = 0;
-    float bestDistance = FLT_MAX;
+    float bestDistance = std::numeric_limits<float>::max();
     bool hit = false;
 
     // Get the reverse child order because we are setting up a depth-first

--- a/src/artifacts.h
+++ b/src/artifacts.h
@@ -26,15 +26,15 @@ class Artifacts
 
             if(clampInvalid) {
                 if(std::isinf(color.r) || std::isinf(color.g) || std::isinf(color.b)) {
-                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has Inf value : " << color.string() << '\n';;
+                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has Inf value : " << color.string() << '\n';
                     isValid = false;
                 }
                 else if(std::isnan(color.r) || std::isnan(color.g) || std::isnan(color.b)) {
-                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has NaN value : " << color.string() << '\n';;
+                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has NaN value : " << color.string() << '\n';
                     isValid = false;
                 }
                 else if(color.r < 0.0f || color.g < 0.0f || color.b < 0.0f) {
-                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has Negative value : " << color.string() << '\n';;
+                    std::cerr << "WARNING: Pixel " << x << ", " << y << " color has Negative value : " << color.string() << '\n';
                     isValid = false;
                 }
             }
@@ -148,14 +148,10 @@ class Artifacts
                 isectDist.set3(x, y, 1.0f, 0.0f, 1.0f);
             else if(distance < minDistance)
                 isectDist.set3(x, y, 0.0f, 1.0f, 1.0f);
-            else if(distance == FLT_MAX)
+            else if(distance == std::numeric_limits<float>::max())
                 isectDist.set3(x, y, 1.0f, 0.5f, 0.0f);
             else {
-#if 1
                 float v = lerpFromTo(distance, 1.0f, 20.0f, 0.0f, 1.0f);
-#else
-                float v = std::log10(distance);
-#endif
                 isectDist.set3(x, y, v, v, v);
             }
         }

--- a/src/fresnel.cpp
+++ b/src/fresnel.cpp
@@ -97,7 +97,7 @@ float normal(float n_i, float n_t)
     return num / denom;
 }
 
-}; // dialectric
+} // dialectric
 
 namespace conductor {
 
@@ -123,7 +123,7 @@ float normal(float n_i, float n_t, float k_t)
     return num / denom;
 }
 
-}; // conductor
+} // conductor
 
-}; // fresnel
+} // fresnel
 

--- a/src/fresnel.h
+++ b/src/fresnel.h
@@ -26,7 +26,7 @@ float perpendicularSnell(float cos_i, float n_i, float n_t);
 
 float normal(float n_i, float n_t);
 
-}; // dialectric
+} // dialectric
 
 namespace conductor {
 
@@ -34,8 +34,8 @@ float unpolarized(float cos_i, float n, float k);
 
 float normal(float n_i, float n_t, float k_t);
 
-}; // conductor
+} // conductor
 
-}; // fresnel
+} // fresnel
 
 #endif

--- a/src/material.h
+++ b/src/material.h
@@ -161,7 +161,7 @@ inline void Material::applyNormalMap(const TextureArray & tex, const TextureCoor
 
     auto map = normalMap(tex, texcoord);
 
-    // Compute new basis by purturbing via the normal map
+    // Compute new basis by perturbing via the normal map
     auto N = (normal * map.z + tangent * map.x + bitangent * map.y).normalized();
     auto T = cross(bitangent, N).normalized();
     auto B = cross(N, T).normalized();

--- a/src/microfacet.h
+++ b/src/microfacet.h
@@ -13,7 +13,7 @@ inline float Function(FunctionSelector selector, float NdH, float NdV, float NdL
 inline float Implicit(float NdV, float NdL);
 inline float CookTorrance(float NdH, float NdV, float NdL, float VdH);
 
-}; // GeometryShadowing
+} // GeometryShadowing
 
 namespace NormalDistribution {
 
@@ -23,7 +23,7 @@ inline float Function(FunctionSelector selector, float roughness, float NdH);
 inline float Beckman(float roughness, float NdH);
 inline float BlinnPhong(float roughness, float NdH);
 
-}; // NormalDistribution
+} // NormalDistribution
 
 // Implementations
 
@@ -51,7 +51,7 @@ inline float CookTorrance(float NdH, float NdV, float NdL, float VdH)
     return std::min(1.0f, std::min(G1, G2));
 }
 
-}; // GeometryShadowing
+} // GeometryShadowing
 
 namespace NormalDistribution {
 
@@ -93,9 +93,9 @@ inline float BlinnPhong(float roughness, float NdH)
     return D;
 }
 
-}; // NormalDistribution
+} // NormalDistribution
 
-}; // Microfacet
+} // Microfacet
 
 
 #endif

--- a/src/scene.h
+++ b/src/scene.h
@@ -40,7 +40,7 @@ struct Scene
     TraceableKDTree objectsKDTree;
     bool useKDTreeAccelerator = false;
 
-    // Always points to a valid envionment map
+    // Always points to a valid environment map
     std::unique_ptr<EnvironmentMap> environmentMap;
 
     MaterialArray materials;

--- a/src/triangle.hpp
+++ b/src/triangle.hpp
@@ -12,7 +12,7 @@ inline bool intersects(const Ray & ray, const Triangle & triangle, float minDist
 
 inline bool findIntersection(const Ray & ray, const Triangle & triangle, float minDistance, RayIntersection & intersection)
 {
-    float t = FLT_MAX;
+    float t = std::numeric_limits<float>::max();
     const auto & v0 = triangle.vertices[0];
     const auto & v1 = triangle.vertices[1];
     const auto & v2 = triangle.vertices[2];


### PR DESCRIPTION
## Summary

- Fix comment typos: "purturbing" -> "perturbing" (`material.h`), "envionment" -> "environment" (`scene.h`), "right size" -> "right side" (`Renderer.cpp`)
- Remove double semicolons in `artifacts.h` and `TraceableKDTree.cpp`
- Remove unnecessary semicolons after namespace closing braces in `fresnel.h`, `fresnel.cpp`, `microfacet.h`
- Standardize on `std::numeric_limits<float>::max()` over `FLT_MAX` in `TriangleMeshOctree.cpp`, `TriangleMesh.cpp`, `triangle.hpp`, `artifacts.h`
- Remove dead `#if 1`/`#else`/`#endif` toggle in `artifacts.h`

Note: the `dialectric` -> `dielectric` namespace rename was skipped because it would break the Python bindings public API and test output filenames.

## Test plan

- [x] Build succeeds with no warnings
- [x] All 19 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)