### PR TITLE
[claude] Add gcov/lcov coverage analysis to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
                  --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch
             lcov --remove coverage.info '*/external/*' '*/unittests/*' '/usr/*' --output-file coverage.info \
                  --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch
-            lcov --list coverage.info
+            lcov --summary coverage.info
       - run:
           name: "Generate HTML Report"
           command: genhtml coverage.info --output-directory coverage-html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,10 @@ jobs:
       - run:
           name: "Collect Coverage"
           command: |
-            lcov --capture --directory build-cov --output-file coverage.info
-            lcov --remove coverage.info '*/external/*' '*/unittests/*' '/usr/*' --output-file coverage.info
+            lcov --capture --directory build-cov --output-file coverage.info \
+                 --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch
+            lcov --remove coverage.info '*/external/*' '*/unittests/*' '/usr/*' --output-file coverage.info \
+                 --rc geninfo_unexecuted_blocks=1 --ignore-errors mismatch
             lcov --list coverage.info
       - run:
           name: "Generate HTML Report"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,10 @@ jobs:
             lcov --remove coverage.info '*/external/*' '*/unittests/*' '/usr/*' --output-file coverage.info
             lcov --list coverage.info
       - run:
-          name: "Upload to Codecov"
-          command: bash <(curl -s https://codecov.io/bash) -f coverage.info
+          name: "Generate HTML Report"
+          command: genhtml coverage.info --output-directory coverage-html
       - store_artifacts:
-          path: coverage.info
+          path: coverage-html
   rendertest:
     docker:
       - image: dacunni/hobby:ubuntu_compilers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,39 @@ jobs:
       - run:
           name: "Test"
           command: cd /workspace/build && ctest --rerun-failed --output-on-failure
+  coverage:
+    docker:
+      - image: dacunni/hobby:ubuntu_compilers
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
+      - run:
+          name: "Setup Coverage Build"
+          command: mkdir build-cov && cd build-cov && cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PYTHON_BINDINGS=OFF ..
+      - run:
+          name: "Build"
+          command: cd build-cov && make -j
+      - run:
+          name: "Run Tests"
+          command: cd build-cov && ctest --output-on-failure
+      - run:
+          name: "Collect Coverage"
+          command: |
+            lcov --capture --directory build-cov --output-file coverage.info
+            lcov --remove coverage.info '*/external/*' '*/unittests/*' '/usr/*' --output-file coverage.info
+            lcov --list coverage.info
+      - run:
+          name: "Upload to Codecov"
+          command: bash <(curl -s https://codecov.io/bash) -f coverage.info
+      - store_artifacts:
+          path: coverage.info
   rendertest:
     docker:
       - image: dacunni/hobby:ubuntu_compilers
@@ -73,6 +106,7 @@ workflows:
       - unittest:
           requires:
             - build
+      - coverage
       - rendertest:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
             git submodule init
             git submodule update --remote
       - run:
+          name: "Install lcov"
+          command: apt-get install -y lcov
+      - run:
           name: "Setup Coverage Build"
           command: mkdir build-cov && cd build-cov && cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PYTHON_BINDINGS=OFF ..
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,11 @@ set(SRCS
     )
 ADD_LIBRARY(fluxrt ${SRCS})
 
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    target_compile_options(fluxrt PUBLIC --coverage -O0 -g)
+    target_link_options(fluxrt PUBLIC --coverage)
+endif()
+
 if(BUILD_PYTHON_BINDINGS)
     add_subdirectory(external/pybind11)
     add_subdirectory(bindings/python)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,10 @@
 PROJECT (fluxrt_tests)
 
-SET(CMAKE_CXX_FLAGS "-std=c++14 -O2")
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    SET(CMAKE_CXX_FLAGS "-std=c++14 -O0 -g --coverage")
+else()
+    SET(CMAKE_CXX_FLAGS "-std=c++14 -O2")
+endif()
 
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary

- Adds a `Coverage` CMake build type to `CMakeLists.txt` and `unittests/CMakeLists.txt` that compiles with `--coverage -O0 -g`
- Adds a parallel `coverage` CircleCI job: fresh checkout → instrumented build → ctest → lcov collection → genhtml report
- Coverage report is stored as a CircleCI artifact and browsable in the Artifacts tab — no third-party service required
- Excludes `external/`, `unittests/`, and system headers from the report so coverage reflects `src/` only
- Runs in parallel with `unittest` and `rendertest` — does not block or slow the critical path

## Test plan

- [ ] CI `coverage` job passes on this branch
- [ ] HTML report appears under Artifacts tab in CircleCI
- [ ] Existing `build`, `unittest`, `rendertest` jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)