### PR TITLE
[claude] Add --annotate option to overlay date, time, and commit hash on output images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,20 @@ include_directories(external/stlloader)
 include_directories(external/cpptoml/include)
 include_directories(external/generator)
 
+# Generate a header containing the current git commit hash, regenerated on
+# every build so it stays accurate (used by --annotate to label output images).
+set(FLUXRT_BUILD_INFO_HEADER ${CMAKE_BINARY_DIR}/generated/build_info.h)
+add_custom_target(fluxrt_build_info ALL
+    COMMAND ${CMAKE_COMMAND}
+        -DSRC_DIR=${CMAKE_SOURCE_DIR}
+        -DTEMPLATE_FILE=${CMAKE_SOURCE_DIR}/cmake/build_info.h.in
+        -DDST_FILE=${FLUXRT_BUILD_INFO_HEADER}
+        -P ${CMAKE_SOURCE_DIR}/cmake/GenerateBuildInfo.cmake
+    BYPRODUCTS ${FLUXRT_BUILD_INFO_HEADER}
+    COMMENT "Generating build info header"
+    )
+include_directories(${CMAKE_BINARY_DIR}/generated)
+
 set(SRCS
     src/artifacts.cpp
     src/AmbientOcclusion.cpp
@@ -65,6 +79,7 @@ set(SRCS
     src/scene.cpp
     src/scene-toml.cpp
     src/texture.cpp
+    src/textoverlay.cpp
     src/timer.cpp
     src/Triangle.cpp
     src/TriangleMesh.cpp
@@ -77,6 +92,7 @@ set(SRCS
     src/ValueArray.cpp
     )
 ADD_LIBRARY(fluxrt ${SRCS})
+add_dependencies(fluxrt fluxrt_build_info)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
     target_compile_options(fluxrt PUBLIC --coverage -O0 -g)

--- a/app/trace_scene.cpp
+++ b/app/trace_scene.cpp
@@ -2,6 +2,9 @@
 #include <unistd.h>
 #include <iostream>
 #include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <atomic>
 #include <signal.h>
 
@@ -17,6 +20,8 @@
 #include "Renderer.h"
 #include "Logger.h"
 #include "LatLonEnvironmentMap.h"
+#include "filesystem.h"
+#include "build_info.h"
 
 std::atomic<bool> flushImmediate(false); // Flush the color output as soon as possible
 
@@ -48,6 +53,7 @@ int main(int argc, char ** argv)
     struct {
         bool help = false;
         bool verbose = false;
+        bool annotate = false;
         unsigned int flushTimeout = 0;
         unsigned int numThreads = 1;
         unsigned int samplesPerPixel = 1;
@@ -73,6 +79,7 @@ int main(int argc, char ** argv)
     // General
     argParser.addFlag('h', "help", options.help);
     argParser.addFlag('v', "verbose", options.verbose);
+    argParser.addFlag('A', "annotate", options.annotate);
     argParser.addArgument('f', "flushtimeout", options.flushTimeout);
     argParser.addArgument('t', "threads", options.numThreads);
     argParser.addArgument('s', "spp", options.samplesPerPixel);
@@ -157,6 +164,17 @@ int main(int argc, char ** argv)
     scene.buildAccelerators();
 
     Artifacts artifacts(scene.sensor.pixelwidth, scene.sensor.pixelheight);
+
+    if(options.annotate) {
+        auto now = std::chrono::system_clock::now();
+        std::time_t nowTime = std::chrono::system_clock::to_time_t(now);
+        std::ostringstream timestamp;
+        timestamp << std::put_time(std::localtime(&nowTime), "%Y-%m-%d %H:%M:%S");
+
+        artifacts.annotation.push_back(timestamp.str());
+        artifacts.annotation.push_back(std::string("commit ") + FLUXRT_GIT_COMMIT_HASH);
+        artifacts.annotation.push_back(std::get<1>(filesystem::splitFileDirectory(sceneFile)));
+    }
 
     auto resetFlushTimer = [&]() {
         if(options.flushTimeout != 0) {

--- a/cmake/GenerateBuildInfo.cmake
+++ b/cmake/GenerateBuildInfo.cmake
@@ -1,0 +1,33 @@
+# Generates an include file containing the current git commit hash so it
+# can be embedded in rendered output (e.g. via the --annotate option).
+#
+# Expects SRC_DIR, TEMPLATE_FILE and DST_FILE to be set on the command line.
+
+find_package(Git QUIET)
+
+set(FLUXRT_GIT_COMMIT_HASH "unknown")
+
+if(GIT_FOUND)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${SRC_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE GIT_RESULT
+    )
+    if(GIT_RESULT EQUAL 0)
+        set(FLUXRT_GIT_COMMIT_HASH "${GIT_HASH}")
+
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} diff --quiet HEAD
+            WORKING_DIRECTORY ${SRC_DIR}
+            RESULT_VARIABLE GIT_DIRTY_RESULT
+        )
+        if(NOT GIT_DIRTY_RESULT EQUAL 0)
+            set(FLUXRT_GIT_COMMIT_HASH "${FLUXRT_GIT_COMMIT_HASH}-dirty")
+        endif()
+    endif()
+endif()
+
+configure_file(${TEMPLATE_FILE} ${DST_FILE} @ONLY)

--- a/cmake/build_info.h.in
+++ b/cmake/build_info.h.in
@@ -1,0 +1,6 @@
+#ifndef __BUILD_INFO_H__
+#define __BUILD_INFO_H__
+
+#define FLUXRT_GIT_COMMIT_HASH "@FLUXRT_GIT_COMMIT_HASH@"
+
+#endif

--- a/src/artifacts.cpp
+++ b/src/artifacts.cpp
@@ -1,6 +1,7 @@
 #include "artifacts.h"
 #include "timer.h"
 #include "tonemapping.h"
+#include "textoverlay.h"
 
 Artifacts::Artifacts()
     : Artifacts(256, 256)
@@ -102,8 +103,13 @@ void Artifacts::writePixelColor()
         image.set(x, y, c, value);
     };
     finalPixelColor.forEachPixelChannel(divideByNumSamples);
-    writePNG(applyStandardGamma(finalPixelColor), prefix + "color.png");
     writeHDR(finalPixelColor, prefix + "color.hdr");
+
+    auto colorImage = applyStandardGamma(finalPixelColor);
+    if(!annotation.empty()) {
+        textoverlay::annotateImage(colorImage, annotation);
+    }
+    writePNG(colorImage, prefix + "color.png");
 
     //float maxValue = finalPixelColor.maxValueAllChannels();
     float maxValue = 4.0f;
@@ -114,6 +120,11 @@ void Artifacts::writePixelColor()
         image.set(x, y, c, value);
     };
     finalPixelColor.forEachPixelChannel(applyToneMap);
-    writePNG(applyStandardGamma(finalPixelColor), prefix + "color_tone_mapped.png");
+
+    auto toneMappedImage = applyStandardGamma(finalPixelColor);
+    if(!annotation.empty()) {
+        textoverlay::annotateImage(toneMappedImage, annotation);
+    }
+    writePNG(toneMappedImage, prefix + "color_tone_mapped.png");
 }
 

--- a/src/artifacts.h
+++ b/src/artifacts.h
@@ -1,6 +1,9 @@
 #ifndef __ARTIFACTS_H__
 #define __ARTIFACTS_H__
 
+#include <string>
+#include <vector>
+
 #include "scene.h"
 #include "image.h"
 #include "constants.h"
@@ -14,6 +17,10 @@ class Artifacts
 
         void writeAll();
         void writePixelColor();
+
+        // Lines of text to overlay onto the final color output images
+        // (e.g. date/time, commit hash). Empty by default.
+        std::vector<std::string> annotation;
 
         inline void accumPixelRadiance(int x, int y, const RadianceRGB & rad)
         {

--- a/src/textoverlay.cpp
+++ b/src/textoverlay.cpp
@@ -1,0 +1,81 @@
+#include <algorithm>
+#include <cmath>
+
+#include "textoverlay.h"
+#include "stb_easy_font.h"
+
+namespace textoverlay {
+
+void drawText(Image<float> & image, int x, int y, const std::string & text,
+               const ColorRGB & color, float scale)
+{
+    // stb_easy_font emits a quad (4 vertices, 16 bytes each: 3 floats + RGBA8)
+    // per stroke segment of the text, laid out as if drawn at the origin.
+    char vertexBuffer[99999];
+    int numQuads = stb_easy_font_print(0, 0, const_cast<char *>(text.c_str()),
+                                        nullptr, vertexBuffer, sizeof(vertexBuffer));
+
+    for(int q = 0; q < numQuads; ++q) {
+        float minX = std::numeric_limits<float>::max(), maxX = std::numeric_limits<float>::lowest();
+        float minY = std::numeric_limits<float>::max(), maxY = std::numeric_limits<float>::lowest();
+
+        for(int v = 0; v < 4; ++v) {
+            const char * vptr = vertexBuffer + (q * 4 + v) * 16;
+            float vx = *reinterpret_cast<const float *>(vptr + 0);
+            float vy = *reinterpret_cast<const float *>(vptr + 4);
+            minX = std::min(minX, vx);
+            maxX = std::max(maxX, vx);
+            minY = std::min(minY, vy);
+            maxY = std::max(maxY, vy);
+        }
+
+        int px0 = x + (int) std::floor(minX * scale);
+        int px1 = x + (int) std::ceil(maxX * scale);
+        int py0 = y + (int) std::floor(minY * scale);
+        int py1 = y + (int) std::ceil(maxY * scale);
+
+        for(int py = py0; py < py1; ++py) {
+            if(py < 0 || py >= (int) image.height) {
+                continue;
+            }
+            for(int px = px0; px < px1; ++px) {
+                if(px < 0 || px >= (int) image.width) {
+                    continue;
+                }
+                image.set3(px, py, color);
+            }
+        }
+    }
+}
+
+void annotateImage(Image<float> & image, const std::vector<std::string> & lines, float scale)
+{
+    if(lines.empty()) {
+        return;
+    }
+
+    const int margin = (int) std::ceil(4 * scale);
+    const int lineHeight = (int) std::ceil(12 * scale);
+
+    int maxTextWidth = 0;
+    for(const auto & line : lines) {
+        int textWidth = stb_easy_font_width(const_cast<char *>(line.c_str()));
+        maxTextWidth = std::max(maxTextWidth, (int) std::ceil(textWidth * scale));
+    }
+
+    int boxWidth = std::min((int) image.width, maxTextWidth + 2 * margin);
+    int boxHeight = std::min((int) image.height, (int) lines.size() * lineHeight + 2 * margin);
+    int boxY0 = (int) image.height - boxHeight;
+
+    for(int y = boxY0; y < (int) image.height; ++y) {
+        for(int x = 0; x < boxWidth; ++x) {
+            image.set3(x, y, ColorRGB::BLACK());
+        }
+    }
+
+    for(size_t i = 0; i < lines.size(); ++i) {
+        drawText(image, margin, boxY0 + margin + (int) i * lineHeight, lines[i], ColorRGB::WHITE(), scale);
+    }
+}
+
+} // namespace textoverlay

--- a/src/textoverlay.h
+++ b/src/textoverlay.h
@@ -12,13 +12,13 @@ namespace textoverlay {
 // Draws a single line of text into the image with its top-left corner at (x, y).
 // Pixels of the glyph strokes are set to the given color.
 void drawText(Image<float> & image, int x, int y, const std::string & text,
-               const ColorRGB & color = ColorRGB::WHITE(), float scale = 2.0f);
+               const ColorRGB & color = ColorRGB::WHITE(), float scale = 1.0f);
 
 // Draws a block of lines of text over a filled background box in the
 // bottom-left corner of the image, for annotating output images with
 // metadata such as date/time and commit hash.
 void annotateImage(Image<float> & image, const std::vector<std::string> & lines,
-                    float scale = 2.0f);
+                    float scale = 1.0f);
 
 } // namespace textoverlay
 

--- a/src/textoverlay.h
+++ b/src/textoverlay.h
@@ -1,0 +1,25 @@
+#ifndef __TEXTOVERLAY_H__
+#define __TEXTOVERLAY_H__
+
+#include <string>
+#include <vector>
+
+#include "image.h"
+#include "color.h"
+
+namespace textoverlay {
+
+// Draws a single line of text into the image with its top-left corner at (x, y).
+// Pixels of the glyph strokes are set to the given color.
+void drawText(Image<float> & image, int x, int y, const std::string & text,
+               const ColorRGB & color = ColorRGB::WHITE(), float scale = 2.0f);
+
+// Draws a block of lines of text over a filled background box in the
+// bottom-left corner of the image, for annotating output images with
+// metadata such as date/time and commit hash.
+void annotateImage(Image<float> & image, const std::vector<std::string> & lines,
+                    float scale = 2.0f);
+
+} // namespace textoverlay
+
+#endif


### PR DESCRIPTION
## Summary
- Adds a `-A` / `--annotate` flag to `trace_scene` that overlays a text block (timestamp, git commit hash, scene file name) in the bottom-left corner of `color.png` and `color_tone_mapped.png`
- Text is rendered with `stb_easy_font` via a new `textoverlay` module (`src/textoverlay.h`/`.cpp`)
- The git commit hash is captured at build time into a generated `build_info.h` header (regenerated on every build via a CMake custom target)
- Default (non-annotated) output is unchanged

## Test plan
- [x] `ctest` — all 21 test suites pass
- [x] Rendered a scene with `-A` and confirmed the overlay shows date/time, commit hash, and scene filename
- [x] Rendered without `-A` and confirmed output is unchanged

Closes #80